### PR TITLE
Add command-line configuration management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,39 @@ go-go-mcp can be configured using YAML configuration files that allow you to:
 - Control access through blacklists/whitelists
 - Manage security through parameter filtering
 
+### Command-Line Configuration Management
+
+The `config` command group provides tools to manage your configuration:
+
+```bash
+# Create a new configuration file
+go-go-mcp config init
+
+# Edit configuration in your default editor
+go-go-mcp config edit
+
+# List available profiles
+go-go-mcp config list-profiles
+
+# Show details of a specific profile
+go-go-mcp config show-profile default
+
+# Add a tool directory to a profile
+go-go-mcp config add-tool default --dir ./tools/system
+
+# Add a specific tool file to a profile
+go-go-mcp config add-tool default --file ./tools/special-tool.yaml
+
+# Create a new profile
+go-go-mcp config add-profile production "Production environment configuration"
+
+# Duplicate an existing profile
+go-go-mcp config duplicate-profile development staging "Staging environment configuration"
+
+# Set the default profile
+go-go-mcp config set-default-profile production
+```
+
 For detailed configuration documentation, use:
 ```bash
 # View configuration file documentation

--- a/changelog.md
+++ b/changelog.md
@@ -928,3 +928,12 @@ Added a helper package for managing profiles configuration paths:
 - Added GetProfilesPath to handle both default and custom paths
 - Updated all config commands to use the new helpers
 - Updated start command to use the new helpers
+
+# Update Configuration Documentation with CLI Tools
+
+Updated the configuration documentation to include the command-line configuration management tools:
+
+- Added config command examples to README.md
+- Updated configuration file tutorial with CLI tool usage
+- Added CLI-based configuration workflow to MCP in Practice guide
+- Improved documentation organization and clarity

--- a/changelog.md
+++ b/changelog.md
@@ -895,3 +895,36 @@ Enhanced the example commands documentation:
 Fixed linter error in randomInt function by renaming variables to avoid conflict with predeclared identifiers.
 
 - Renamed min to minVal and max to maxVal in randomInt function
+
+# Configuration Management Commands
+
+Added a new `config` command group to manage go-go-mcp configuration files and profiles:
+- `init`: Create a new minimal configuration file
+- `edit`: Edit configuration in default editor
+- `list-profiles`: List all available profiles
+- `show-profile`: Show full configuration of a profile
+- `add-tool`: Add tool directory or file to a profile
+- `add-profile`: Create a new profile
+- `duplicate-profile`: Create a new profile by duplicating an existing one
+
+# YAML Editor and Config Management
+
+Added a new YAML editor package in clay for manipulating YAML files while preserving comments and structure:
+- Added YAMLEditor type with methods for manipulating YAML nodes
+- Added helper functions for creating and manipulating YAML nodes
+- Added support for preserving comments and formatting
+- Added deep copy functionality for YAML nodes
+
+Updated the config commands to use the new YAML editor:
+- Added ConfigEditor type for managing go-go-mcp configuration
+- Updated all config commands to use the new editor
+- Added set-default-profile command
+- Improved error handling and validation
+
+# Profiles Path Helper
+
+Added a helper package for managing profiles configuration paths:
+- Added GetDefaultProfilesPath to get the default XDG config path
+- Added GetProfilesPath to handle both default and custom paths
+- Updated all config commands to use the new helpers
+- Updated start command to use the new helpers

--- a/cmd/go-go-mcp/cmds/config.go
+++ b/cmd/go-go-mcp/cmds/config.go
@@ -1,0 +1,370 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/go-go-golems/go-go-mcp/pkg/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+type Profile struct {
+	Description string        `yaml:"description"`
+	Tools       ToolSources   `yaml:"tools"`
+	Prompts     PromptSources `yaml:"prompts"`
+}
+
+type ToolSources struct {
+	Directories []DirectorySource `yaml:"directories,omitempty"`
+	Files       []FileSource      `yaml:"files,omitempty"`
+}
+
+type PromptSources struct {
+	Directories []DirectorySource `yaml:"directories,omitempty"`
+	Files       []FileSource      `yaml:"files,omitempty"`
+}
+
+type DirectorySource struct {
+	Path      string                            `yaml:"path"`
+	Defaults  map[string]map[string]interface{} `yaml:"defaults,omitempty"`
+	Overrides map[string]map[string]interface{} `yaml:"overrides,omitempty"`
+	Whitelist map[string][]string               `yaml:"whitelist,omitempty"`
+	Blacklist map[string][]string               `yaml:"blacklist,omitempty"`
+}
+
+type FileSource struct {
+	Path      string                            `yaml:"path"`
+	Defaults  map[string]map[string]interface{} `yaml:"defaults,omitempty"`
+	Overrides map[string]map[string]interface{} `yaml:"overrides,omitempty"`
+}
+
+type Config struct {
+	Version        string             `yaml:"version"`
+	DefaultProfile string             `yaml:"defaultProfile"`
+	Profiles       map[string]Profile `yaml:"profiles"`
+}
+
+func NewConfigGroupCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage go-go-mcp configuration",
+		Long:  `Commands for managing go-go-mcp configuration files and profiles.`,
+	}
+
+	cmd.AddCommand(NewConfigInitCommand())
+	cmd.AddCommand(NewConfigEditCommand())
+	cmd.AddCommand(NewConfigListProfilesCommand())
+	cmd.AddCommand(NewConfigShowProfileCommand())
+	cmd.AddCommand(NewConfigAddToolCommand())
+	cmd.AddCommand(NewConfigAddProfileCommand())
+	cmd.AddCommand(NewConfigDuplicateProfileCommand())
+	cmd.AddCommand(NewConfigSetDefaultProfileCommand())
+
+	return cmd
+}
+
+func NewConfigInitCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Initialize a new configuration file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			// Create directory if it doesn't exist
+			configDir := filepath.Dir(configFile)
+			if err := os.MkdirAll(configDir, 0755); err != nil {
+				return fmt.Errorf("could not create config directory: %w", err)
+			}
+
+			// Check if file already exists
+			if _, err := os.Stat(configFile); err == nil {
+				return fmt.Errorf("config file already exists at %s", configFile)
+			}
+
+			// Create minimal config
+			editor, err := config.NewConfigEditor(configFile)
+			if err != nil {
+				return fmt.Errorf("could not create config editor: %w", err)
+			}
+
+			err = editor.AddProfile("default", "Default profile with basic configuration")
+			if err != nil {
+				return fmt.Errorf("could not add default profile: %w", err)
+			}
+
+			err = editor.SetDefaultProfile("default")
+			if err != nil {
+				return fmt.Errorf("could not set default profile: %w", err)
+			}
+
+			err = editor.AddToolDirectory("default", "./tools", map[string]interface{}{
+				"debug":   false,
+				"verbose": false,
+			})
+			if err != nil {
+				return fmt.Errorf("could not add tool directory: %w", err)
+			}
+
+			if err := editor.Save(); err != nil {
+				return fmt.Errorf("could not save config file: %w", err)
+			}
+
+			fmt.Printf("Created new config file at %s\n", configFile)
+			return nil
+		},
+	}
+}
+
+func NewConfigEditCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "edit",
+		Short: "Edit the configuration file in your default editor",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			editor := os.Getenv("EDITOR")
+			if editor == "" {
+				editor = "vim"
+			}
+
+			editCmd := exec.Command(editor, configFile)
+			editCmd.Stdin = os.Stdin
+			editCmd.Stdout = os.Stdout
+			editCmd.Stderr = os.Stderr
+
+			return editCmd.Run()
+		},
+	}
+}
+
+func NewConfigListProfilesCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-profiles",
+		Short: "List all available profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			editor, err := config.NewConfigEditor(configFile)
+			if err != nil {
+				return fmt.Errorf("could not create config editor: %w", err)
+			}
+
+			defaultProfile, err := editor.GetDefaultProfile()
+			if err != nil {
+				return fmt.Errorf("could not get default profile: %w", err)
+			}
+
+			profiles, err := editor.GetProfiles()
+			if err != nil {
+				return fmt.Errorf("could not get profiles: %w", err)
+			}
+
+			fmt.Printf("Default profile: %s\n\n", defaultProfile)
+			fmt.Println("Available profiles:")
+			for name, desc := range profiles {
+				fmt.Printf("- %s: %s\n", name, desc)
+			}
+
+			return nil
+		},
+	}
+}
+
+func NewConfigShowProfileCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show-profile [profile-name]",
+		Short: "Show the full configuration of a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			editor, err := config.NewConfigEditor(configFile)
+			if err != nil {
+				return fmt.Errorf("could not create config editor: %w", err)
+			}
+
+			profile, err := editor.GetProfile(args[0])
+			if err != nil {
+				return fmt.Errorf("could not get profile: %w", err)
+			}
+
+			data, err := yaml.Marshal(profile)
+			if err != nil {
+				return fmt.Errorf("could not marshal profile: %w", err)
+			}
+
+			fmt.Printf("Profile: %s\n\n%s", args[0], string(data))
+			return nil
+		},
+	}
+}
+
+func NewConfigAddToolCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-tool [profile-name] [--dir path | --file path]",
+		Short: "Add a tool directory or file to a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, _ := cmd.Flags().GetString("dir")
+			file, _ := cmd.Flags().GetString("file")
+
+			if (dir == "" && file == "") || (dir != "" && file != "") {
+				return fmt.Errorf("exactly one of --dir or --file must be specified")
+			}
+
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			editor, err := config.NewConfigEditor(configFile)
+			if err != nil {
+				return fmt.Errorf("could not create config editor: %w", err)
+			}
+
+			if dir != "" {
+				err = editor.AddToolDirectory(args[0], dir, map[string]interface{}{
+					"debug":   false,
+					"verbose": false,
+				})
+				if err != nil {
+					return fmt.Errorf("could not add tool directory: %w", err)
+				}
+			} else {
+				err = editor.AddToolFile(args[0], file)
+				if err != nil {
+					return fmt.Errorf("could not add tool file: %w", err)
+				}
+			}
+
+			if err := editor.Save(); err != nil {
+				return fmt.Errorf("could not save config file: %w", err)
+			}
+
+			fmt.Printf("Added tool to profile %s\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().String("dir", "", "Directory path to add")
+	cmd.Flags().String("file", "", "File path to add")
+
+	return cmd
+}
+
+func NewConfigAddProfileCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add-profile [profile-name] [description]",
+		Short: "Add a new profile",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			editor, err := config.NewConfigEditor(configFile)
+			if err != nil {
+				return fmt.Errorf("could not create config editor: %w", err)
+			}
+
+			err = editor.AddProfile(args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("could not add profile: %w", err)
+			}
+
+			if err := editor.Save(); err != nil {
+				return fmt.Errorf("could not save config file: %w", err)
+			}
+
+			fmt.Printf("Added new profile: %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func NewConfigDuplicateProfileCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "duplicate-profile [source-profile] [new-profile] [description]",
+		Short: "Duplicate an existing profile with a new name",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			editor, err := config.NewConfigEditor(configFile)
+			if err != nil {
+				return fmt.Errorf("could not create config editor: %w", err)
+			}
+
+			err = editor.DuplicateProfile(args[0], args[1], args[2])
+			if err != nil {
+				return fmt.Errorf("could not duplicate profile: %w", err)
+			}
+
+			if err := editor.Save(); err != nil {
+				return fmt.Errorf("could not save config file: %w", err)
+			}
+
+			fmt.Printf("Duplicated profile %s to %s\n", args[0], args[1])
+			return nil
+		},
+	}
+}
+
+func NewConfigSetDefaultProfileCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-default-profile [profile-name]",
+		Short: "Set the default profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := viper.ConfigFileUsed()
+			configFile, err := config.GetProfilesPath(configFile)
+			if err != nil {
+				return fmt.Errorf("could not get profiles path: %w", err)
+			}
+
+			editor, err := config.NewConfigEditor(configFile)
+			if err != nil {
+				return fmt.Errorf("could not create config editor: %w", err)
+			}
+
+			err = editor.SetDefaultProfile(args[0])
+			if err != nil {
+				return fmt.Errorf("could not set default profile: %w", err)
+			}
+
+			if err := editor.Save(); err != nil {
+				return fmt.Errorf("could not save config file: %w", err)
+			}
+
+			fmt.Printf("Set default profile to %s\n", args[0])
+			return nil
+		},
+	}
+}

--- a/cmd/go-go-mcp/cmds/start.go
+++ b/cmd/go-go-mcp/cmds/start.go
@@ -35,11 +35,10 @@ type StartCommand struct {
 }
 
 func NewStartCommand() (*StartCommand, error) {
-	xdgConfigPath, err := os.UserConfigDir()
+	defaultConfigFile, err := config.GetDefaultProfilesPath()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get user config directory")
+		return nil, errors.Wrap(err, "failed to get default profiles path")
 	}
-	defaultConfigFile := fmt.Sprintf("%s/go-go-mcp/profiles.yaml", xdgConfigPath)
 
 	return &StartCommand{
 		CommandDescription: cmds.NewCommandDescription(

--- a/cmd/go-go-mcp/main.go
+++ b/cmd/go-go-mcp/main.go
@@ -96,6 +96,10 @@ func initRootCmd() (*help.HelpSystem, error) {
 	bridgeCmd := server_cmds.NewBridgeCommand(log.Logger)
 	rootCmd.AddCommand(bridgeCmd)
 
+	// Add config command group
+	configCmd := server_cmds.NewConfigGroupCommand()
+	rootCmd.AddCommand(configCmd)
+
 	return helpSystem, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
-	github.com/go-go-golems/clay v0.1.21
+	github.com/go-go-golems/clay v0.1.22
 	github.com/go-go-golems/geppetto v0.4.34
 	github.com/go-go-golems/glazed v0.5.27
 	github.com/go-go-golems/parka v0.5.17
@@ -18,6 +18,7 @@ require (
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
+	github.com/spf13/viper v1.19.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -91,7 +92,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.19.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tj/go-naturaldate v1.3.0 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
-	github.com/go-go-golems/clay v0.1.22
+	github.com/go-go-golems/clay v0.1.23
 	github.com/go-go-golems/geppetto v0.4.34
 	github.com/go-go-golems/glazed v0.5.27
 	github.com/go-go-golems/parka v0.5.17

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-go-golems/clay v0.1.21 h1:dW6qLKcVdpUOiY3iaXtcZrzGFEoVan7L5H+dJkDMbto=
-github.com/go-go-golems/clay v0.1.21/go.mod h1:oS1t0/5pDbMpO+WqkKh94ddokbivW3dDX8Zqvy4JxYw=
+github.com/go-go-golems/clay v0.1.22 h1:07+W31MjaGMxd296bgNCaNeFasCHhiVLiMPqT/VhPVA=
+github.com/go-go-golems/clay v0.1.22/go.mod h1:oS1t0/5pDbMpO+WqkKh94ddokbivW3dDX8Zqvy4JxYw=
 github.com/go-go-golems/geppetto v0.4.34 h1:kVQqVqrXPPa+4tRPqAxTbvOAomM9XKd255nuUdBFCfE=
 github.com/go-go-golems/geppetto v0.4.34/go.mod h1:HGEsHKvH8HKH89CLWIcueYm46bue7LdFTtsFos3Uzyo=
 github.com/go-go-golems/glazed v0.5.27 h1:rTzxL0vp/uBxVvZqJsyIxIFZ1zN/CSJ5qOtc8j87gBs=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-go-golems/clay v0.1.22 h1:07+W31MjaGMxd296bgNCaNeFasCHhiVLiMPqT/VhPVA=
-github.com/go-go-golems/clay v0.1.22/go.mod h1:oS1t0/5pDbMpO+WqkKh94ddokbivW3dDX8Zqvy4JxYw=
+github.com/go-go-golems/clay v0.1.23 h1:IPzxS1mTcU1GWjkjON5ed+mpjqhGVvXmn6M6cplpJr4=
+github.com/go-go-golems/clay v0.1.23/go.mod h1:oS1t0/5pDbMpO+WqkKh94ddokbivW3dDX8Zqvy4JxYw=
 github.com/go-go-golems/geppetto v0.4.34 h1:kVQqVqrXPPa+4tRPqAxTbvOAomM9XKd255nuUdBFCfE=
 github.com/go-go-golems/geppetto v0.4.34/go.mod h1:HGEsHKvH8HKH89CLWIcueYm46bue7LdFTtsFos3Uzyo=
 github.com/go-go-golems/glazed v0.5.27 h1:rTzxL0vp/uBxVvZqJsyIxIFZ1zN/CSJ5qOtc8j87gBs=

--- a/pkg/config/editor.go
+++ b/pkg/config/editor.go
@@ -94,7 +94,7 @@ func (c *ConfigEditor) AddToolDirectory(profile, path string, defaults map[strin
 
 	// Get or create the directories sequence
 	var dirSeqNode *yaml.Node
-	dirSeqNode, err = c.editor.GetMapNode("directories", toolsNode)
+	_, err = c.editor.GetMapNode("directories", toolsNode)
 	if err != nil {
 		// Create new directories sequence
 		dirSeqNode = &yaml.Node{Kind: yaml.SequenceNode}
@@ -130,7 +130,7 @@ func (c *ConfigEditor) AddToolFile(profile, path string) error {
 
 	// Get or create the files sequence
 	var fileSeqNode *yaml.Node
-	fileSeqNode, err = c.editor.GetMapNode("files", toolsNode)
+	_, err = c.editor.GetMapNode("files", toolsNode)
 	if err != nil {
 		// Create new files sequence
 		fileSeqNode = &yaml.Node{Kind: yaml.SequenceNode}

--- a/pkg/config/editor.go
+++ b/pkg/config/editor.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"fmt"
+
+	yaml_editor "github.com/go-go-golems/clay/pkg/yaml-editor"
+	"gopkg.in/yaml.v3"
+)
+
+type ConfigEditor struct {
+	editor *yaml_editor.YAMLEditor
+	path   string
+}
+
+func NewConfigEditor(path string) (*ConfigEditor, error) {
+	editor, err := yaml_editor.NewYAMLEditorFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not create editor: %w", err)
+	}
+
+	return &ConfigEditor{
+		editor: editor,
+		path:   path,
+	}, nil
+}
+
+func (c *ConfigEditor) Save() error {
+	return c.editor.Save(c.path)
+}
+
+func (c *ConfigEditor) AddProfile(name, description string) error {
+	// Create a new profile node
+	profileNode, err := c.editor.CreateMap(
+		"description", description,
+		"tools", &yaml.Node{Kind: yaml.MappingNode},
+		"prompts", &yaml.Node{Kind: yaml.MappingNode},
+	)
+	if err != nil {
+		return fmt.Errorf("could not create profile node: %w", err)
+	}
+
+	// Add the profile to the profiles map
+	err = c.editor.SetNode(profileNode, "profiles", name)
+	if err != nil {
+		return fmt.Errorf("could not add profile: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ConfigEditor) DuplicateProfile(source, target, description string) error {
+	// Get the source profile
+	sourceNode, err := c.editor.GetNode("profiles", source)
+	if err != nil {
+		return fmt.Errorf("could not get source profile: %w", err)
+	}
+
+	// Create a deep copy of the source profile
+	targetNode := c.editor.DeepCopyNode(sourceNode)
+
+	// Update the description
+	descNode, err := c.editor.GetMapNode("description", targetNode)
+	if err != nil {
+		return fmt.Errorf("could not get description node: %w", err)
+	}
+	descNode.Value = description
+
+	// Add the new profile
+	err = c.editor.SetNode(targetNode, "profiles", target)
+	if err != nil {
+		return fmt.Errorf("could not add target profile: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ConfigEditor) AddToolDirectory(profile, path string, defaults map[string]interface{}) error {
+	// Create the directory source node
+	dirNode, err := c.editor.CreateMap(
+		"path", path,
+		"defaults", map[string]interface{}{
+			"default": defaults,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("could not create directory node: %w", err)
+	}
+
+	// Get the tools node
+	toolsNode, err := c.editor.GetNode("profiles", profile, "tools")
+	if err != nil {
+		return fmt.Errorf("could not get tools node: %w", err)
+	}
+
+	// Get or create the directories sequence
+	var dirSeqNode *yaml.Node
+	dirSeqNode, err = c.editor.GetMapNode("directories", toolsNode)
+	if err != nil {
+		// Create new directories sequence
+		dirSeqNode = &yaml.Node{Kind: yaml.SequenceNode}
+		err = c.editor.SetNode(dirSeqNode, "profiles", profile, "tools", "directories")
+		if err != nil {
+			return fmt.Errorf("could not create directories sequence: %w", err)
+		}
+	}
+
+	// Append the new directory
+	err = c.editor.AppendToSequence(dirNode, "profiles", profile, "tools", "directories")
+	if err != nil {
+		return fmt.Errorf("could not append directory: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ConfigEditor) AddToolFile(profile, path string) error {
+	// Create the file source node
+	fileNode, err := c.editor.CreateMap(
+		"path", path,
+	)
+	if err != nil {
+		return fmt.Errorf("could not create file node: %w", err)
+	}
+
+	// Get the tools node
+	toolsNode, err := c.editor.GetNode("profiles", profile, "tools")
+	if err != nil {
+		return fmt.Errorf("could not get tools node: %w", err)
+	}
+
+	// Get or create the files sequence
+	var fileSeqNode *yaml.Node
+	fileSeqNode, err = c.editor.GetMapNode("files", toolsNode)
+	if err != nil {
+		// Create new files sequence
+		fileSeqNode = &yaml.Node{Kind: yaml.SequenceNode}
+		err = c.editor.SetNode(fileSeqNode, "profiles", profile, "tools", "files")
+		if err != nil {
+			return fmt.Errorf("could not create files sequence: %w", err)
+		}
+	}
+
+	// Append the new file
+	err = c.editor.AppendToSequence(fileNode, "profiles", profile, "tools", "files")
+	if err != nil {
+		return fmt.Errorf("could not append file: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ConfigEditor) SetDefaultProfile(profile string) error {
+	// Create a scalar node with the profile name
+	profileNode := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: profile,
+	}
+
+	// Set it as the default profile
+	err := c.editor.SetNode(profileNode, "defaultProfile")
+	if err != nil {
+		return fmt.Errorf("could not set default profile: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ConfigEditor) GetProfiles() (map[string]string, error) {
+	// Get the profiles node
+	profilesNode, err := c.editor.GetNode("profiles")
+	if err != nil {
+		return nil, fmt.Errorf("could not get profiles node: %w", err)
+	}
+
+	profiles := make(map[string]string)
+	for i := 0; i < len(profilesNode.Content); i += 2 {
+		name := profilesNode.Content[i].Value
+		profile := profilesNode.Content[i+1]
+
+		// Get description
+		descNode, err := c.editor.GetMapNode("description", profile)
+		if err != nil {
+			return nil, fmt.Errorf("could not get description for profile %s: %w", name, err)
+		}
+
+		profiles[name] = descNode.Value
+	}
+
+	return profiles, nil
+}
+
+func (c *ConfigEditor) GetProfile(name string) (*yaml.Node, error) {
+	return c.editor.GetNode("profiles", name)
+}
+
+func (c *ConfigEditor) GetDefaultProfile() (string, error) {
+	node, err := c.editor.GetNode("defaultProfile")
+	if err != nil {
+		return "", fmt.Errorf("could not get default profile: %w", err)
+	}
+
+	return node.Value, nil
+}

--- a/pkg/config/paths.go
+++ b/pkg/config/paths.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GetDefaultProfilesPath returns the default path for the profiles configuration file
+func GetDefaultProfilesPath() (string, error) {
+	xdgConfigPath, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(xdgConfigPath, "go-go-mcp", "profiles.yaml"), nil
+}
+
+// GetProfilesPath returns the profiles path from either the provided path or the default location
+func GetProfilesPath(configFile string) (string, error) {
+	if configFile != "" {
+		return configFile, nil
+	}
+	return GetDefaultProfilesPath()
+}

--- a/pkg/doc/topics/01-config-file.md
+++ b/pkg/doc/topics/01-config-file.md
@@ -34,7 +34,44 @@ This tutorial will guide you through creating and using configuration files in g
 
 ## Basic Configuration
 
-Let's start with a minimal configuration file:
+The easiest way to get started is to use the built-in configuration management commands:
+
+```bash
+# Create a new configuration file
+go-go-mcp config init
+
+# Edit the configuration in your default editor
+go-go-mcp config edit
+```
+
+This will create a minimal configuration file with a default profile. You can then add more profiles and tools:
+
+```bash
+# Add a new profile
+go-go-mcp config add-profile development "Development environment with debug tools"
+
+# Add tool directories to the profile
+go-go-mcp config add-tool development --dir ./tools/system
+go-go-mcp config add-tool development --dir ./tools/data
+
+# Set it as the default profile
+go-go-mcp config set-default-profile development
+
+# View your profiles
+go-go-mcp config list-profiles
+
+# Show the full configuration of a profile
+go-go-mcp config show-profile development
+```
+
+You can also create profiles by duplicating existing ones:
+
+```bash
+# Create a staging profile based on development
+go-go-mcp config duplicate-profile development staging "Staging environment"
+```
+
+Alternatively, you can manually create a configuration file with this minimal structure:
 
 ```yaml
 version: "1"

--- a/pkg/doc/topics/03-mcp-in-practice.md
+++ b/pkg/doc/topics/03-mcp-in-practice.md
@@ -385,7 +385,55 @@ Key points:
 
 ## Configuring MCP
 
-Now let's create a configuration file that organizes tools by their use cases. Create `config.yaml`:
+Let's set up our configuration using the built-in configuration management tools:
+
+1. **Initialize Configuration**
+   ```bash
+   # Create a new configuration file
+   go-go-mcp config init
+   
+   # Edit it in your default editor to review
+   go-go-mcp config edit
+   ```
+
+2. **Create Profiles for Different Environments**
+   ```bash
+   # Create development profile
+   go-go-mcp config add-profile development "Development environment with debug tools"
+   
+   # Add tool directories
+   go-go-mcp config add-tool development --dir ./tools/system
+   go-go-mcp config add-tool development --dir ./tools/data
+   
+   # Create production profile
+   go-go-mcp config add-profile production "Production environment with strict controls"
+   
+   # Add production tools
+   go-go-mcp config add-tool production --dir /opt/go-go-mcp/tools
+   
+   # Create staging by duplicating development
+   go-go-mcp config duplicate-profile development staging "Staging environment"
+   ```
+
+3. **Review Configuration**
+   ```bash
+   # List all profiles
+   go-go-mcp config list-profiles
+   
+   # Show development profile configuration
+   go-go-mcp config show-profile development
+   
+   # Show production profile configuration
+   go-go-mcp config show-profile production
+   ```
+
+4. **Set Default Profile**
+   ```bash
+   # Set development as default for local work
+   go-go-mcp config set-default-profile development
+   ```
+
+Now let's create a configuration file that organizes tools by their use cases:
 
 ## Working with Configuration Files
 


### PR DESCRIPTION
Adds a new `config` command group for managing go-go-mcp configuration files and profiles
through the command line:

Key features:
- Create and edit configuration files with `init` and `edit` commands
- Manage profiles with `add-profile`, `duplicate-profile`, and `set-default-profile`
- Add tool sources with `add-tool --dir` and `add-tool --file`
- List and inspect profiles with `list-profiles` and `show-profile`
- Preserves comments and formatting when editing configuration files

Technical changes:
- YAML editor package for manipulating YAML while preserving structure
- Config editor type for managing go-go-mcp specific configuration
- Path helpers for handling default and custom config locations
- Updated documentation with CLI configuration workflow examples

The changes make it easier to create and maintain configuration files through a 
consistent CLI interface rather than manual editing.