### PR TITLE
Add session management and improve SQLite tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ dist/
 .history
 __debug*
 
-.specstory
+.specstory/
+.history/
+

--- a/cmd/go-go-mcp/cmds/server/start.go
+++ b/cmd/go-go-mcp/cmds/server/start.go
@@ -87,7 +87,7 @@ func registerInternalServers(registry *tool_registry.Registry, serverList []stri
 
 	// Register the requested servers
 	if serversMap["sqlite"] {
-		if err := examples.RegisterSQLiteTool(registry); err != nil {
+		if err := examples.RegisterSQLiteSessionTools(registry); err != nil {
 			return errors.Wrap(err, "failed to register sqlite tool")
 		}
 	}

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/go-go-golems/go-go-mcp/pkg"
+	"github.com/go-go-golems/go-go-mcp/pkg/session"
 )
 
 type ServerOption func(*Server)
@@ -33,5 +34,13 @@ func WithServerName(name string) ServerOption {
 func WithServerVersion(version string) ServerOption {
 	return func(s *Server) {
 		s.serverVersion = version
+	}
+}
+
+func WithSessionStore(store session.SessionStore) ServerOption {
+	return func(s *Server) {
+		if store != nil {
+			s.sessionStore = store
+		}
 	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1,0 +1,89 @@
+package session
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+type SessionID string
+
+// SessionState holds arbitrary data for a session.
+type SessionState map[string]interface{}
+
+// Session represents a client session.
+type Session struct {
+	ID    SessionID
+	State SessionState
+	mu    sync.RWMutex
+	// TODO: Add metadata like CreationTime, LastAccessTime
+}
+
+// contextKey is an unexported type for context keys defined in this package.
+// This prevents collisions with keys defined in other packages.
+type contextKey string
+
+// sessionContextKey is the key used to store the Session in the context.
+const sessionContextKey = contextKey("session")
+
+// WithSession returns a new context derived from ctx that carries the provided session.
+func WithSession(ctx context.Context, session *Session) context.Context {
+	return context.WithValue(ctx, sessionContextKey, session)
+}
+
+// GetSessionFromContext retrieves the Session stored in the context, if any.
+func GetSessionFromContext(ctx context.Context) (*Session, bool) {
+	session, ok := ctx.Value(sessionContextKey).(*Session)
+	return session, ok
+}
+
+func NewSession() *Session {
+	return &Session{
+		ID:    SessionID(uuid.New().String()),
+		State: make(SessionState),
+	}
+}
+
+// SetData stores a key-value pair in the session's state.
+// It is thread-safe.
+func (s *Session) SetData(key string, value interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.State == nil {
+		s.State = make(SessionState)
+	}
+	s.State[key] = value
+	log.Debug().Str("sessionID", string(s.ID)).Str("key", key).Msg("Set data in session")
+}
+
+// GetData retrieves a value from the session's state by key.
+// The boolean return value indicates whether the key was found.
+// It is thread-safe.
+func (s *Session) GetData(key string) (interface{}, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.State == nil {
+		return nil, false
+	}
+	value, ok := s.State[key]
+	if ok {
+		log.Debug().Str("sessionID", string(s.ID)).Str("key", key).Msg("Get data from session")
+	} else {
+		log.Debug().Str("sessionID", string(s.ID)).Str("key", key).Msg("Data not found in session")
+	}
+	return value, ok
+}
+
+// DeleteData removes a key-value pair from the session's state.
+// It is thread-safe.
+func (s *Session) DeleteData(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.State == nil {
+		return
+	}
+	delete(s.State, key)
+	log.Debug().Str("sessionID", string(s.ID)).Str("key", key).Msg("Deleted data from session")
+}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// SessionStore defines the interface for managing sessions.
+type SessionStore interface {
+	Get(sessionID SessionID) (*Session, bool)
+	Create() *Session
+	Update(session *Session) // Note: For in-memory, Get returns a pointer, so Update might be implicit.
+	Delete(sessionID SessionID)
+	// TODO: Add cleanup mechanism for stale sessions
+}
+
+// InMemorySessionStore provides a thread-safe in-memory implementation of SessionStore.
+type InMemorySessionStore struct {
+	mu       sync.RWMutex
+	sessions map[SessionID]*Session
+}
+
+// NewInMemorySessionStore creates a new in-memory session store.
+func NewInMemorySessionStore() *InMemorySessionStore {
+	return &InMemorySessionStore{
+		sessions: make(map[SessionID]*Session),
+	}
+}
+
+// Get retrieves a session by its ID.
+func (s *InMemorySessionStore) Get(sessionID SessionID) (*Session, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	session, ok := s.sessions[sessionID]
+	return session, ok
+}
+
+// Create generates a new session with a unique ID and adds it to the store.
+func (s *InMemorySessionStore) Create() *Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	newSession := &Session{
+		ID:    SessionID(uuid.NewString()),
+		State: make(SessionState),
+	}
+	s.sessions[newSession.ID] = newSession
+	return newSession
+}
+
+// Update stores the potentially modified session state.
+// For this in-memory store using pointers, changes to the retrieved session
+// are inherently reflected. This method ensures the session exists.
+func (s *InMemorySessionStore) Update(session *Session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Just ensure it's in the map, assuming modifications happened on the pointer
+	if _, exists := s.sessions[session.ID]; exists {
+		s.sessions[session.ID] = session
+	}
+	// Optionally, add logic here if sessions need explicit saving or validation
+}
+
+// Delete removes a session from the store.
+func (s *InMemorySessionStore) Delete(sessionID SessionID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, sessionID)
+}
+
+// Ensure InMemorySessionStore implements SessionStore
+var _ SessionStore = (*InMemorySessionStore)(nil)

--- a/pkg/tools/examples/sqlite.go
+++ b/pkg/tools/examples/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/go-go-golems/go-go-mcp/pkg/protocol"
 	"github.com/go-go-golems/go-go-mcp/pkg/session"
@@ -65,13 +66,25 @@ func registerSQLiteOpenTool(registry *tool_registry.Registry) error {
 				return protocol.NewToolResult(protocol.WithError("no session found in context")), nil
 			}
 
-			// Close existing connection if any
-			closeSessionDB(s) // Best effort closing
-
 			dbPath := defaultDBPath
 			if filePath, pathOK := arguments["file_path"].(string); pathOK && filePath != "" {
 				dbPath = filePath
 			}
+
+			// Check if this DB is already open in the session
+			if existingPathVal, pathOk := s.GetData(sessionDBPathKey); pathOk {
+				if existingPath, ok := existingPathVal.(string); ok && existingPath == dbPath {
+					if _, connOk := s.GetData(sessionDBConnectionKey); connOk {
+						log.Info().Str("sessionID", string(s.ID)).Str("dbPath", dbPath).Msg("SQLite database already open in session")
+						return protocol.NewToolResult(
+							protocol.WithText(fmt.Sprintf("Database already open: %s", dbPath)),
+						), nil
+					}
+				}
+			}
+
+			// If not already open or different path requested, close existing connection if any
+			closeSessionDB(s) // Best effort closing
 
 			db, err := sql.Open("sqlite3", dbPath)
 			if err != nil {
@@ -271,39 +284,127 @@ func registerSQLiteQueryTool(registry *tool_registry.Registry) error {
 					continue
 				}
 
-				rows, err := db.QueryContext(ctx, query)
-				if err != nil {
-					queryErr = errors.Wrapf(err, "error executing query %d", i)
-					queryLogger.Error().
-						Err(err).
-						Msg("Failed to execute SQLite query")
+				trimmedQuery := strings.TrimSpace(query)
+				upperQuery := strings.ToUpper(trimmedQuery)
 
-					allResults = append(allResults, map[string]interface{}{
-						"query": query,
-						"error": err.Error(),
-					})
-					continue // Move to the next query
-				}
-
-				queryLogger.Debug().Msg("Successfully executed query, processing results")
-
-				processResult, err := processQueryResults(rows, query)
-				_ = rows.Close() // Close rows immediately after processing
-				if err != nil {
-					queryErr = errors.Wrapf(err, "error processing results for query %d", i)
-					queryLogger.Error().
-						Err(err).
-						Msg("Failed to process query results")
-
-					// Add error information to this query's result map
-					processResult["error"] = err.Error()
+				// Check if this is a comment-only query
+				if trimmedQuery == "" || strings.HasPrefix(trimmedQuery, "--") {
+					processResult := map[string]interface{}{
+						"query":  query,
+						"status": "comment or empty query - skipped",
+					}
+					queryLogger.Debug().Msg("Skipping comment or empty query")
 					allResults = append(allResults, processResult)
-					continue // Move to the next query
+					continue
 				}
 
-				queryLogger.Debug().
-					Interface("result", processResult).
-					Msg("Successfully processed query results")
+				// Determine query type
+				isSelect := strings.HasPrefix(upperQuery, "SELECT") ||
+					strings.HasPrefix(upperQuery, "WITH")
+				isDML := strings.HasPrefix(upperQuery, "UPDATE") ||
+					strings.HasPrefix(upperQuery, "INSERT") ||
+					strings.HasPrefix(upperQuery, "DELETE") ||
+					strings.HasPrefix(upperQuery, "REPLACE")
+				isAdminCommand := strings.HasPrefix(upperQuery, "CREATE") ||
+					strings.HasPrefix(upperQuery, "DROP") ||
+					strings.HasPrefix(upperQuery, "PRAGMA") ||
+					strings.HasPrefix(upperQuery, "ALTER") ||
+					strings.HasPrefix(upperQuery, "TRUNCATE") ||
+					strings.HasPrefix(upperQuery, "BEGIN") ||
+					strings.HasPrefix(upperQuery, "START TRANSACTION") ||
+					strings.HasPrefix(upperQuery, "COMMIT") ||
+					strings.HasPrefix(upperQuery, "ROLLBACK") ||
+					strings.HasPrefix(upperQuery, "SAVEPOINT") ||
+					strings.HasPrefix(upperQuery, "RELEASE") ||
+					strings.HasPrefix(upperQuery, "VACUUM") ||
+					strings.HasPrefix(upperQuery, "ANALYZE") ||
+					strings.HasPrefix(upperQuery, "ATTACH") ||
+					strings.HasPrefix(upperQuery, "DETACH") ||
+					strings.HasPrefix(upperQuery, "REINDEX") ||
+					strings.HasPrefix(upperQuery, "EXPLAIN")
+
+				var processResult map[string]interface{}
+				if isSelect {
+					// Use QueryContext for SELECT statements
+					rows, err := db.QueryContext(ctx, query)
+					if err != nil {
+						queryErr = errors.Wrapf(err, "error executing SELECT query %d", i)
+						queryLogger.Error().
+							Err(err).
+							Msg("Failed to execute SQLite SELECT query")
+
+						processResult = map[string]interface{}{
+							"query": query,
+							"error": err.Error(),
+						}
+					} else {
+						queryLogger.Debug().Msg("Successfully executed query, processing results")
+
+						var processErr error
+						processResult, processErr = processQueryResults(rows, query)
+						_ = rows.Close() // Close rows immediately after processing
+						if processErr != nil {
+							queryErr = errors.Wrapf(processErr, "error processing results for query %d", i)
+							queryLogger.Error().
+								Err(processErr).
+								Msg("Failed to process query results")
+
+							// Add error information to this query's result map
+							processResult["error"] = processErr.Error()
+						}
+					}
+				} else if isAdminCommand || isDML {
+					// Use ExecContext for DML and admin commands
+					res, err := db.ExecContext(ctx, query)
+					if err != nil {
+						queryErr = errors.Wrapf(err, "error executing query %d", i)
+						queryLogger.Error().
+							Err(err).
+							Msg("Failed to execute SQLite query")
+
+						processResult = map[string]interface{}{
+							"query": query,
+							"error": err.Error(),
+						}
+					} else {
+						processResult = map[string]interface{}{
+							"query":  query,
+							"status": "executed successfully",
+						}
+
+						// For DML statements, always try to get rows affected
+						if isDML {
+							rowsAffected, err := res.RowsAffected()
+							if err != nil {
+								queryLogger.Error().
+									Err(err).
+									Msg("Failed to get rows affected")
+								processResult["error"] = fmt.Sprintf("query succeeded but failed to get rows affected: %v", err)
+							} else {
+								processResult["rows_affected"] = rowsAffected
+								if rowsAffected == 0 && !strings.Contains(upperQuery, "WHERE 1=0") {
+									// If no rows were affected and this wasn't explicitly intended (WHERE 1=0),
+									// add a warning
+									processResult["warning"] = "query succeeded but no rows were affected"
+								}
+							}
+						}
+
+						lastID, err := res.LastInsertId()
+						if err == nil && lastID > 0 {
+							processResult["last_insert_id"] = lastID
+						}
+
+						queryLogger.Debug().
+							Interface("result", processResult).
+							Msg("Successfully executed query")
+					}
+				} else {
+					processResult = map[string]interface{}{
+						"query":  query,
+						"status": "unknown query type",
+					}
+				}
 
 				allResults = append(allResults, processResult)
 			}
@@ -335,11 +436,16 @@ func registerSQLiteQueryTool(registry *tool_registry.Registry) error {
 
 // processQueryResults converts sql.Rows into a map structure suitable for YAML marshalling.
 func processQueryResults(rows *sql.Rows, query string) (map[string]interface{}, error) {
+	logger := log.Logger.With().Str("query", query).Logger()
+
 	// Get column names
 	columns, err := rows.Columns()
 	if err != nil {
+		logger.Error().Err(err).Msg("Failed to get column names")
 		return map[string]interface{}{"query": query}, errors.Wrap(err, "error getting columns")
 	}
+
+	logger.Debug().Strs("columns", columns).Msg("Retrieved column names")
 
 	// Prepare result storage
 	values := make([]interface{}, len(columns))
@@ -347,43 +453,93 @@ func processQueryResults(rows *sql.Rows, query string) (map[string]interface{}, 
 	for i := range columns {
 		valuePtrs[i] = &values[i]
 	}
+	if len(columns) == 0 {
+		return map[string]interface{}{"query": query}, nil
+	}
 
 	// Build results for this query
 	var queryResults []map[string]interface{}
+	rowNum := 0
+	totalBytes := 0
+
+	queryResultMap := map[string]interface{}{
+		"query":   query,
+		"results": queryResults,
+	}
+
+	// Calculate initial size with just the query
+	initialBytes, err := yaml.Marshal(queryResultMap)
+	if err != nil {
+		return queryResultMap, errors.Wrap(err, "error calculating initial size")
+	}
+	totalBytes = len(initialBytes)
+
 	for rows.Next() {
+		rowNum++
+		if rowNum > 1000 {
+			queryResults = append(queryResults, map[string]interface{}{
+				"warning": "Stopping after 1000 rows",
+			})
+			break
+		}
+		rowLogger := logger.With().Int("row", rowNum).Logger()
+
 		err := rows.Scan(valuePtrs...)
 		if err != nil {
+			rowLogger.Error().Err(err).Msg("Failed to scan row")
 			return map[string]interface{}{"query": query}, errors.Wrap(err, "error scanning row")
 		}
 
 		row := make(map[string]interface{})
 		for i, col := range columns {
 			val := values[i]
-			// Handle BLOBs/bytes as strings for YAML output, adjust if needed
+			// Handle BLOBs/bytes as strings for YAML output
 			b, ok := val.([]byte)
 			if ok {
 				row[col] = string(b)
 			} else {
-				// Handle potential nil values explicitly if necessary
 				if val == nil {
-					row[col] = nil // Or "" or some placeholder
+					row[col] = nil
 				} else {
 					row[col] = val
 				}
 			}
 		}
+
 		queryResults = append(queryResults, row)
+		queryResultMap["results"] = queryResults
+
+		// Check size after adding new row
+		bytes, err := yaml.Marshal(queryResultMap)
+		if err != nil {
+			rowLogger.Error().Err(err).Msg("Failed to marshal results")
+			continue
+		}
+
+		totalBytes = len(bytes)
+		if totalBytes > 10000 {
+			// Remove last row that put us over the limit
+			queryResults = queryResults[:len(queryResults)-1]
+			queryResults = append(queryResults, map[string]interface{}{
+				"warning": "Results truncated due to size limit of 10000 bytes",
+			})
+			break
+		}
+
+		rowLogger.Debug().Interface("row_data", row).Msg("Processed row")
 	}
 
 	if err = rows.Err(); err != nil {
+		logger.Error().Err(err).Msg("Error occurred while iterating rows")
 		return map[string]interface{}{"query": query}, errors.Wrap(err, "error iterating rows")
 	}
 
-	// Add query results to the overall results
-	queryResultMap := map[string]interface{}{
-		"query":   query,
-		"results": queryResults,
-	}
+	logger.Debug().
+		Int("total_rows", rowNum).
+		Int("total_bytes", totalBytes).
+		Msg("Finished processing rows")
+
+	queryResultMap["results"] = queryResults
 	return queryResultMap, nil
 }
 

--- a/pkg/tools/examples/sqlite.go
+++ b/pkg/tools/examples/sqlite.go
@@ -7,36 +7,54 @@ import (
 	"fmt"
 
 	"github.com/go-go-golems/go-go-mcp/pkg/protocol"
+	"github.com/go-go-golems/go-go-mcp/pkg/session"
 	"github.com/go-go-golems/go-go-mcp/pkg/tools"
 	tool_registry "github.com/go-go-golems/go-go-mcp/pkg/tools/providers/tool-registry"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 )
 
-const defaultDBPath = "/home/manuel/.config/Cursor/User/globalStorage/state.vscdb"
+const (
+	defaultDBPath          = "/home/manuel/.config/Cursor/User/globalStorage/state.vscdb"
+	sessionDBConnectionKey = "sqlite_db_connection"
+	sessionDBPathKey       = "sqlite_db_path"
+)
 
-func RegisterSQLiteTool(registry *tool_registry.Registry) error {
+// RegisterSQLiteSessionTools registers three tools: sqlite_open, sqlite_query, and sqlite_close.
+// sqlite_open: Opens a SQLite database and stores the connection in the session.
+// sqlite_query: Executes queries against the session's open database or a default one.
+// sqlite_close: Closes the SQLite database connection stored in the session.
+func RegisterSQLiteSessionTools(registry *tool_registry.Registry) error {
+	if err := registerSQLiteOpenTool(registry); err != nil {
+		return errors.Wrap(err, "failed to register sqlite_open tool")
+	}
+	if err := registerSQLiteQueryTool(registry); err != nil {
+		return errors.Wrap(err, "failed to register sqlite_query tool")
+	}
+	if err := registerSQLiteCloseTool(registry); err != nil {
+		return errors.Wrap(err, "failed to register sqlite_close tool")
+	}
+	return nil
+}
+
+// registerSQLiteOpenTool registers the tool to open a database connection.
+func registerSQLiteOpenTool(registry *tool_registry.Registry) error {
 	schemaJson := `{
 		"type": "object",
 		"properties": {
-			"queries": {
-				"type": "array",
-				"items": {
-					"type": "string"
-				},
-				"description": "A list of SQL queries to execute sequentially against Cursor's SQLite database. The database contains AI conversation history, IDE state, and other Cursor-related data. Common tables include 'cursorDiskKV' for conversation storage. Note: SQLite dot commands like .tables are not supported as they are CLI-specific features. Use standard SQL queries instead."
-			},
 			"file_path": {
 				"type": "string",
-				"description": "Path to the SQLite database file. If not provided, the default Cursor database path will be used."
+				"description": "Path to the SQLite database file to open. If not provided, the default Cursor database path will be used."
 			}
 		},
-		"required": ["queries"]
+		"required": []
 	}`
 
 	tool, err := tools.NewToolImpl(
-		"sqlite",
-		"Execute SQL queries against the Cursor IDE's SQLite database and output results as YAML. This tool provides direct access to Cursor's underlying data storage, allowing complex queries for conversation analysis, usage patterns, and IDE state. Useful for advanced data analysis or when the higher-level conversation tools are insufficient.",
+		"sqlite_open",
+		"Opens a SQLite database connection and stores it in the current session. Subsequent 'sqlite_query' calls will use this connection.",
 		json.RawMessage(schemaJson))
 	if err != nil {
 		return err
@@ -44,113 +62,288 @@ func RegisterSQLiteTool(registry *tool_registry.Registry) error {
 
 	registry.RegisterToolWithHandler(
 		tool,
-		func(ctx context.Context, tool tools.Tool, arguments map[string]interface{}) (*protocol.ToolResult, error) {
-			queries, ok := arguments["queries"].([]interface{})
+		func(ctx context.Context, _ tools.Tool, arguments map[string]interface{}) (*protocol.ToolResult, error) {
+			s, ok := session.GetSessionFromContext(ctx)
 			if !ok {
-				return protocol.NewToolResult(
-					protocol.WithError("queries argument must be an array of strings"),
-				), nil
+				return protocol.NewToolResult(protocol.WithError("no session found in context")), nil
 			}
 
+			// Close existing connection if any
+			closeSessionDB(s) // Best effort closing
+
 			dbPath := defaultDBPath
-			if filePath, ok := arguments["file_path"].(string); ok && filePath != "" {
+			if filePath, pathOK := arguments["file_path"].(string); pathOK && filePath != "" {
 				dbPath = filePath
 			}
 
 			db, err := sql.Open("sqlite3", dbPath)
 			if err != nil {
 				return protocol.NewToolResult(
-					protocol.WithError(fmt.Sprintf("error opening database: %v", err)),
+					protocol.WithError(fmt.Sprintf("error opening database '%s': %v", dbPath, err)),
 				), nil
 			}
-			defer func() {
-				if closeErr := db.Close(); closeErr != nil {
-					if err == nil {
-						err = closeErr
+
+			// Test connection
+			if err := db.PingContext(ctx); err != nil {
+				_ = db.Close()
+				return protocol.NewToolResult(
+					protocol.WithError(fmt.Sprintf("error pinging database '%s': %v", dbPath, err)),
+				), nil
+			}
+
+			// Store connection and path in session
+			s.SetData(sessionDBConnectionKey, db)
+			s.SetData(sessionDBPathKey, dbPath)
+
+			log.Info().Str("sessionID", string(s.ID)).Str("dbPath", dbPath).Msg("SQLite database opened and stored in session")
+
+			return protocol.NewToolResult(
+				protocol.WithText(fmt.Sprintf("Successfully opened database: %s", dbPath)),
+			), nil
+		})
+
+	return nil
+}
+
+// registerSQLiteCloseTool registers the tool to close the session's database connection.
+func registerSQLiteCloseTool(registry *tool_registry.Registry) error {
+	schemaJson := `{
+		"type": "object",
+		"properties": {},
+		"required": []
+	}`
+
+	tool, err := tools.NewToolImpl(
+		"sqlite_close",
+		"Closes the SQLite database connection currently stored in the session.",
+		json.RawMessage(schemaJson))
+	if err != nil {
+		return err
+	}
+
+	registry.RegisterToolWithHandler(
+		tool,
+		func(ctx context.Context, _ tools.Tool, arguments map[string]interface{}) (*protocol.ToolResult, error) {
+			s, ok := session.GetSessionFromContext(ctx)
+			if !ok {
+				return protocol.NewToolResult(protocol.WithError("no session found in context")), nil
+			}
+
+			closedPath, closed := closeSessionDB(s)
+			if !closed {
+				return protocol.NewToolResult(
+					protocol.WithText("No active SQLite database connection found in the session to close."),
+				), nil
+			}
+
+			log.Info().Str("sessionID", string(s.ID)).Str("dbPath", closedPath).Msg("SQLite database closed from session")
+			return protocol.NewToolResult(
+				protocol.WithText(fmt.Sprintf("Successfully closed database connection for: %s", closedPath)),
+			), nil
+		})
+
+	return nil
+}
+
+// closeSessionDB closes the database connection stored in the session, if it exists.
+// It returns the path of the closed DB and true if a connection was found and closed, otherwise empty string and false.
+func closeSessionDB(s *session.Session) (string, bool) {
+	dbPath := ""
+	pathVal, pathOk := s.GetData(sessionDBPathKey)
+	if pathOk {
+		dbPath = pathVal.(string)
+	}
+
+	connVal, ok := s.GetData(sessionDBConnectionKey)
+	if !ok {
+		log.Debug().Str("sessionID", string(s.ID)).Msg("No DB connection found in session to close")
+		return "", false // No connection to close
+	}
+
+	db, ok := connVal.(*sql.DB)
+	if !ok {
+		log.Warn().Str("sessionID", string(s.ID)).Msg("Session data for DB connection is not *sql.DB")
+		// Attempt to remove potentially corrupted data
+		s.DeleteData(sessionDBConnectionKey)
+		s.DeleteData(sessionDBPathKey)
+		return "", false
+	}
+
+	err := db.Close()
+	s.DeleteData(sessionDBConnectionKey) // Remove even if close failed
+	s.DeleteData(sessionDBPathKey)
+
+	if err != nil {
+		log.Error().Err(err).Str("sessionID", string(s.ID)).Str("dbPath", dbPath).Msg("Error closing session SQLite database")
+		// We still report closed=true because we removed the entry
+	} else {
+		log.Debug().Str("sessionID", string(s.ID)).Str("dbPath", dbPath).Msg("Closed session SQLite database")
+	}
+	return dbPath, true
+}
+
+// registerSQLiteQueryTool registers the tool to execute SQL queries.
+func registerSQLiteQueryTool(registry *tool_registry.Registry) error {
+	schemaJson := `{
+		"type": "object",
+		"properties": {
+			"queries": {
+				"type": "array",
+				"items": { "type": "string" },
+				"description": "A list of SQL queries to execute. Uses the connection opened by 'sqlite_open' if available, otherwise uses the default Cursor DB."
+			},
+			"file_path": {
+				"type": "string",
+				"description": "Path to the SQLite database file. Only used if no connection is open in the session. If neither session connection nor file_path is provided, the default Cursor database path is used."
+			}
+		},
+		"required": ["queries"]
+	}`
+
+	tool, err := tools.NewToolImpl(
+		"sqlite_query",
+		"Execute SQL queries against the session's open SQLite database or a specified/default one, outputting results as YAML.",
+		json.RawMessage(schemaJson))
+	if err != nil {
+		return err
+	}
+
+	registry.RegisterToolWithHandler(
+		tool,
+		func(ctx context.Context, _ tools.Tool, arguments map[string]interface{}) (*protocol.ToolResult, error) {
+			queriesArg, ok := arguments["queries"]
+			if !ok {
+				return protocol.NewToolResult(protocol.WithError("missing required argument 'queries'")), nil
+			}
+			queriesInterfaces, ok := queriesArg.([]interface{})
+			if !ok {
+				return protocol.NewToolResult(protocol.WithError("'queries' argument must be an array of strings")), nil
+			}
+			if len(queriesInterfaces) == 0 {
+				return protocol.NewToolResult(protocol.WithError("'queries' array must not be empty")), nil
+			}
+
+			queries := make([]string, len(queriesInterfaces))
+			for i, q := range queriesInterfaces {
+				queryStr, ok := q.(string)
+				if !ok {
+					return protocol.NewToolResult(protocol.WithError(fmt.Sprintf("query at index %d is not a string", i))), nil
+				}
+				queries[i] = queryStr
+			}
+
+			var db *sql.DB
+			var dbPath string
+			var closeDbFunc func() // Function to close the DB if opened temporarily
+			var sessionUsed bool
+
+			s, sessionOk := session.GetSessionFromContext(ctx)
+			if sessionOk {
+				if connVal, connOk := s.GetData(sessionDBConnectionKey); connOk {
+					var dbOk bool
+					db, dbOk = connVal.(*sql.DB)
+					if !dbOk {
+						log.Warn().Str("sessionID", string(s.ID)).Msg("Session data for DB connection is not *sql.DB, ignoring")
+						// Proceed as if no session connection exists
+					} else {
+						sessionUsed = true
+						if pathVal, pathOk := s.GetData(sessionDBPathKey); pathOk {
+							dbPath = pathVal.(string)
+						} else {
+							dbPath = "[unknown session path]"
+						}
+						log.Debug().Str("sessionID", string(s.ID)).Str("dbPath", dbPath).Msg("Using SQLite connection from session")
 					}
 				}
-			}()
+			}
 
-			// Store results for each query
-			allResults := make([]map[string]interface{}, 0)
+			// If no valid session DB, try opening one based on file_path or default
+			if !sessionUsed {
+				dbPath = defaultDBPath
+				if filePathArg, ok := arguments["file_path"].(string); ok && filePathArg != "" {
+					dbPath = filePathArg
+				}
+				log.Debug().Str("dbPath", dbPath).Msg("Opening temporary SQLite connection")
 
-			// Execute each query sequentially
-			for i, q := range queries {
-				query, ok := q.(string)
-				if !ok {
+				var openErr error
+				db, openErr = sql.Open("sqlite3", dbPath)
+				if openErr != nil {
 					return protocol.NewToolResult(
-						protocol.WithError(fmt.Sprintf("query at index %d is not a string", i)),
+						protocol.WithError(fmt.Sprintf("error opening database '%s': %v", dbPath, openErr)),
 					), nil
+				}
+				closeDbFunc = func() {
+					if err := db.Close(); err != nil {
+						log.Error().Err(err).Str("dbPath", dbPath).Msg("Error closing temporary SQLite database")
+					} else {
+						log.Debug().Str("dbPath", dbPath).Msg("Closed temporary SQLite database")
+					}
+				}
+				// Test connection
+				if err := db.PingContext(ctx); err != nil {
+					closeDbFunc()
+					return protocol.NewToolResult(
+						protocol.WithError(fmt.Sprintf("error pinging database '%s': %v", dbPath, err)),
+					), nil
+				}
+			}
+
+			// Ensure temporary DB is closed if opened
+			if closeDbFunc != nil {
+				defer closeDbFunc()
+			}
+
+			// Execute queries
+			allResults := make([]map[string]interface{}, 0, len(queries))
+			var queryErr error // To store the first error encountered
+
+			for i, query := range queries {
+				if queryErr != nil {
+					// If a previous query failed, add placeholders for subsequent queries
+					allResults = append(allResults, map[string]interface{}{
+						"query": query,
+						"error": "Skipped due to previous error",
+					})
+					continue
 				}
 
 				rows, err := db.QueryContext(ctx, query)
 				if err != nil {
-					return protocol.NewToolResult(
-						protocol.WithError(fmt.Sprintf("error executing query %d: %v", i, err)),
-					), nil
+					queryErr = errors.Wrapf(err, "error executing query %d", i)
+					allResults = append(allResults, map[string]interface{}{
+						"query": query,
+						"error": err.Error(),
+					})
+					continue // Move to the next query
 				}
 
-				// Get column names
-				columns, err := rows.Columns()
+				processResult, err := processQueryResults(rows, query)
+				_ = rows.Close() // Close rows immediately after processing
 				if err != nil {
-					_ = rows.Close()
-					return protocol.NewToolResult(
-						protocol.WithError(fmt.Sprintf("error getting columns for query %d: %v", i, err)),
-					), nil
+					queryErr = errors.Wrapf(err, "error processing results for query %d", i)
+					// Add error information to this query's result map
+					processResult["error"] = err.Error()
+					allResults = append(allResults, processResult)
+					continue // Move to the next query
 				}
 
-				// Prepare result storage
-				values := make([]interface{}, len(columns))
-				valuePtrs := make([]interface{}, len(columns))
-				for i := range columns {
-					valuePtrs[i] = &values[i]
-				}
-
-				// Build results for this query
-				var queryResults []map[string]interface{}
-				for rows.Next() {
-					err := rows.Scan(valuePtrs...)
-					if err != nil {
-						_ = rows.Close()
-						return protocol.NewToolResult(
-							protocol.WithError(fmt.Sprintf("error scanning row for query %d: %v", i, err)),
-						), nil
-					}
-
-					row := make(map[string]interface{})
-					for i, col := range columns {
-						val := values[i]
-						b, ok := val.([]byte)
-						if ok {
-							row[col] = string(b)
-						} else {
-							row[col] = val
-						}
-					}
-					queryResults = append(queryResults, row)
-				}
-
-				if err = rows.Err(); err != nil {
-					_ = rows.Close()
-					return protocol.NewToolResult(
-						protocol.WithError(fmt.Sprintf("error iterating rows for query %d: %v", i, err)),
-					), nil
-				}
-				_ = rows.Close()
-
-				// Add query results to the overall results
-				queryResult := map[string]interface{}{
-					"query":   query,
-					"results": queryResults,
-				}
-				allResults = append(allResults, queryResult)
+				allResults = append(allResults, processResult)
 			}
 
 			// Convert results to YAML
 			yamlData, err := yaml.Marshal(allResults)
 			if err != nil {
+				// This error happens after query execution, return results error
 				return protocol.NewToolResult(
-					protocol.WithError(fmt.Sprintf("error converting results to YAML: %v", err)),
+					protocol.WithError(fmt.Sprintf("error converting results to YAML: %v. Query execution status: %v", err, queryErr)),
+				), nil
+			}
+
+			// If there was a query error, return it in the protocol error field
+			if queryErr != nil {
+				return protocol.NewToolResult(
+					protocol.WithText(string(yamlData)),
+					protocol.WithError(queryErr.Error()),
 				), nil
 			}
 
@@ -161,3 +354,69 @@ func RegisterSQLiteTool(registry *tool_registry.Registry) error {
 
 	return nil
 }
+
+// processQueryResults converts sql.Rows into a map structure suitable for YAML marshalling.
+func processQueryResults(rows *sql.Rows, query string) (map[string]interface{}, error) {
+	// Get column names
+	columns, err := rows.Columns()
+	if err != nil {
+		return map[string]interface{}{"query": query}, errors.Wrap(err, "error getting columns")
+	}
+
+	// Prepare result storage
+	values := make([]interface{}, len(columns))
+	valuePtrs := make([]interface{}, len(columns))
+	for i := range columns {
+		valuePtrs[i] = &values[i]
+	}
+
+	// Build results for this query
+	var queryResults []map[string]interface{}
+	for rows.Next() {
+		err := rows.Scan(valuePtrs...)
+		if err != nil {
+			return map[string]interface{}{"query": query}, errors.Wrap(err, "error scanning row")
+		}
+
+		row := make(map[string]interface{})
+		for i, col := range columns {
+			val := values[i]
+			// Handle BLOBs/bytes as strings for YAML output, adjust if needed
+			b, ok := val.([]byte)
+			if ok {
+				row[col] = string(b)
+			} else {
+				// Handle potential nil values explicitly if necessary
+				if val == nil {
+					row[col] = nil // Or "" or some placeholder
+				} else {
+					row[col] = val
+				}
+			}
+		}
+		queryResults = append(queryResults, row)
+	}
+
+	if err = rows.Err(); err != nil {
+		return map[string]interface{}{"query": query}, errors.Wrap(err, "error iterating rows")
+	}
+
+	// Add query results to the overall results
+	queryResultMap := map[string]interface{}{
+		"query":   query,
+		"results": queryResults,
+	}
+	return queryResultMap, nil
+}
+
+// TODO: Remove the old registration function or rename it if needed elsewhere
+/*
+func RegisterSQLiteTool(registry *tool_registry.Registry) error {
+	// ... old implementation ...
+}
+*/
+
+// Ensure Tool interfaces are implemented (optional, but good practice)
+var _ tools.Tool = (*tools.ToolImpl)(nil) // Assuming ToolImpl is the concrete type returned by NewToolImpl
+// We don't have direct access to the handler type, so this check is less direct
+// var _ tool_registry.ToolHandler = func(ctx context.Context, tool tools.Tool, arguments map[string]interface{}) (*protocol.ToolResult, error) { return nil, nil }

--- a/pkg/transport/errors.go
+++ b/pkg/transport/errors.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/go-go-golems/go-go-mcp/pkg/protocol"
 )
@@ -64,5 +65,47 @@ func NewTimeoutError(msg string) *protocol.Error {
 	return &protocol.Error{
 		Code:    ErrCodeTimeout,
 		Message: fmt.Sprintf("Timeout error: %s", msg),
+	}
+}
+
+// ProcessError converts a Go error into a standard JSON-RPC Error object.
+// It tries to map known transport errors to specific codes, otherwise defaults to Internal Error.
+func ProcessError(err error) *protocol.Error {
+	// Check if the error is already a *protocol.Error
+	if jsonRPCErr, ok := err.(*protocol.Error); ok {
+		return jsonRPCErr
+	}
+
+	// TODO(manuel): Add more specific error type checks if needed, e.g., os.IsNotExist
+
+	// Default to internal error
+	return NewInternalError(err.Error())
+}
+
+// ErrorToHTTPStatus maps JSON-RPC error codes to appropriate HTTP status codes.
+func ErrorToHTTPStatus(code int) int {
+	switch code {
+	case ErrCodeParse:
+		return http.StatusBadRequest // 400
+	case ErrCodeInvalidRequest:
+		return http.StatusBadRequest // 400
+	case ErrCodeMethodNotFound:
+		return http.StatusNotFound // 404
+	case ErrCodeInvalidParams:
+		return http.StatusBadRequest // 400
+	case ErrCodeInternal:
+		return http.StatusInternalServerError // 500
+	case ErrCodeTransport:
+		return http.StatusInternalServerError // 500 (or specific transport issue code?)
+	case ErrCodeTimeout:
+		return http.StatusGatewayTimeout // 504
+	default:
+		// Handle custom server errors (-32000 to -32099)
+		if code >= -32099 && code <= -32000 {
+			// You might map specific custom codes to HTTP statuses here
+			return http.StatusInternalServerError // Default for custom errors
+		}
+		// For any other codes, default to Internal Server Error
+		return http.StatusInternalServerError // 500
 	}
 }

--- a/pkg/transport/sse/transport.go
+++ b/pkg/transport/sse/transport.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-go-golems/go-go-mcp/pkg/protocol"
+	"github.com/go-go-golems/go-go-mcp/pkg/session"
 	"github.com/go-go-golems/go-go-mcp/pkg/transport"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -18,40 +19,43 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// contextKey is a custom type for context keys to avoid collisions
-type contextKey string
-
 const (
-	sessionIDKey contextKey = "sessionID"
+	// XXX: Deprecate this in favor of pkg/session.GetSessionFromContext
+	// sessionIDKey contextKey = "sessionID"
+
+	// SessionCookieName is the name of the cookie used to store the session ID
+	SessionCookieName = "mcp_session_id"
 )
 
-// GetSessionID retrieves the session ID from the context.
-// Returns an empty string and false if not found.
-func GetSessionID(ctx context.Context) (string, bool) {
-	sessionID, ok := ctx.Value(sessionIDKey).(string)
-	return sessionID, ok
-}
+// // GetSessionID retrieves the session ID from the context.
+// // Returns an empty string and false if not found.
+// func GetSessionID(ctx context.Context) (string, bool) {
+// 	sessionID, ok := ctx.Value(sessionIDKey).(string)
+// 	return sessionID, ok
+// }
 
 type SSETransport struct {
-	mu         sync.RWMutex
-	logger     zerolog.Logger
-	clients    map[string]*SSEClient
-	server     *http.Server
-	port       int
-	handler    transport.RequestHandler
-	nextID     int
-	wg         sync.WaitGroup
-	cancel     context.CancelFunc
-	standalone bool // indicates if we manage our own server
+	mu           sync.RWMutex
+	logger       zerolog.Logger
+	clients      map[string]*SSEClient              // Map clientID -> client
+	sessions     map[session.SessionID][]*SSEClient // Map sessionID -> list of clients
+	server       *http.Server
+	port         int
+	handler      transport.RequestHandler
+	sessionStore session.SessionStore // Added session store
+	wg           sync.WaitGroup
+	cancel       context.CancelFunc
+	standalone   bool // indicates if we manage our own server
 }
 
 type SSEClient struct {
 	id          string
-	sessionID   string
+	sessionID   session.SessionID
 	messageChan chan *protocol.Response
 	createdAt   time.Time
 	remoteAddr  string
 	userAgent   string
+	logger      zerolog.Logger
 }
 
 // SSEHandlers contains the HTTP handlers for SSE endpoints
@@ -76,7 +80,7 @@ func NewSSETransport(opts ...transport.TransportOption) (*SSETransport, error) {
 	}
 
 	s := &SSETransport{
-		logger:     options.Logger,
+		logger:     options.Logger.With().Str("component", "sse_transport").Logger(),
 		clients:    make(map[string]*SSEClient),
 		port:       8080, // Default port
 		standalone: true, // Default to standalone mode
@@ -99,6 +103,9 @@ func NewSSETransport(opts ...transport.TransportOption) (*SSETransport, error) {
 		}
 		s.port = port
 	}
+
+	// Initialize sessions map
+	s.sessions = make(map[session.SessionID][]*SSEClient)
 
 	return s, nil
 }
@@ -163,35 +170,33 @@ func (s *SSETransport) Send(ctx context.Context, response *protocol.Response) er
 	defer s.mu.RUnlock()
 
 	// Find client by session ID from context
-	sessionID, ok := GetSessionID(ctx)
+	session_, ok := session.GetSessionFromContext(ctx)
 	if !ok {
 		return fmt.Errorf("session ID not found in context")
 	}
 
 	var targetClients []*SSEClient
 	for _, client := range s.clients {
-		if client.sessionID == sessionID {
+		if client.sessionID == session_.ID {
 			targetClients = append(targetClients, client)
 		}
 	}
 
 	if len(targetClients) == 0 {
-		return fmt.Errorf("no clients found for session %s", sessionID)
+		return fmt.Errorf("no clients found for session %s", session_.ID)
 	}
 
 	// Send to all clients in the session
 	for _, client := range targetClients {
 		select {
 		case client.messageChan <- response:
-			s.logger.Debug().
-				Str("client_id", client.id).
-				Str("sessionId", sessionID).
+			client.logger.Debug().
+				Str("sessionId", string(session_.ID)).
 				Interface("response", response).
 				Msg("Response sent to client")
 		default:
-			s.logger.Error().
-				Str("client_id", client.id).
-				Str("sessionId", sessionID).
+			client.logger.Error().
+				Str("sessionId", string(session_.ID)).
 				Msg("Failed to send response to client")
 		}
 	}
@@ -209,10 +214,13 @@ func (s *SSETransport) Close(ctx context.Context) error {
 			s.cancel()
 		}
 
-		for sessionID, client := range s.clients {
-			s.logger.Debug().Str("sessionId", sessionID).Msg("Closing client connection")
-			close(client.messageChan)
-			delete(s.clients, sessionID)
+		for sessionID, clients := range s.sessions {
+			s.logger.Debug().Str("sessionId", string(sessionID)).Msg("Closing client connections")
+			for _, client := range clients {
+				close(client.messageChan)
+				delete(s.clients, client.id)
+			}
+			delete(s.sessions, sessionID)
 		}
 
 		s.mu.Unlock()
@@ -255,21 +263,42 @@ func (s *SSETransport) Info() transport.TransportInfo {
 }
 
 func (s *SSETransport) handleSSE(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+	s.mu.Lock()
+	if s.handler == nil {
+		s.mu.Unlock()
+		s.logger.Error().Msg("Handler not set")
+		http.Error(w, "Server not ready", http.StatusInternalServerError)
+		return
+	}
+	if s.sessionStore == nil {
+		s.mu.Unlock()
+		s.logger.Error().Msg("Session store not set")
+		http.Error(w, "Server configuration error", http.StatusInternalServerError)
+		return
+	}
+	s.mu.Unlock() // Unlock early, lock specific sections below
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
-	sessionID := r.URL.Query().Get("sessionId")
-	if sessionID == "" {
-		sessionID = uuid.New().String()
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
+		return
 	}
 
-	s.mu.Lock()
-	s.nextID++
-	clientID := fmt.Sprintf("client-%d", s.nextID)
+	// Get or create session
+	ctx := r.Context()
+	currentSession, sessionID := s.getSessionFromRequest(r)
+	if currentSession == nil {
+		// Should not happen if getSessionFromRequest works correctly, but handle defensively
+		currentSession = s.sessionStore.Create()
+		sessionID = currentSession.ID
+		s.logger.Info().Str("session_id", string(sessionID)).Msg("Created new session (edge case)")
+	}
+
+	// Set session cookie
+	s.setSessionCookie(w, sessionID)
+
+	// Create a new client for this connection
+	clientID := uuid.New().String()
 	client := &SSEClient{
 		id:          clientID,
 		sessionID:   sessionID,
@@ -277,95 +306,265 @@ func (s *SSETransport) handleSSE(w http.ResponseWriter, r *http.Request) {
 		createdAt:   time.Now(),
 		remoteAddr:  r.RemoteAddr,
 		userAgent:   r.UserAgent(),
+		logger: s.logger.With().
+			Str("client_id", clientID).
+			Str("session_id", string(sessionID)).
+			Str("remote_addr", r.RemoteAddr).
+			Logger(),
 	}
-	log.Info().Str("client_id", clientID).
-		Str("session_id", sessionID).
-		Msg("New client connected")
+
+	s.mu.Lock()
 	s.clients[clientID] = client
+	s.sessions[sessionID] = append(s.sessions[sessionID], client)
 	s.mu.Unlock()
+
+	client.logger.Info().Msg("Client connected")
+
+	// Set headers for SSE
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*") // Allow CORS for debugging
 
 	s.wg.Add(1)
 	defer s.wg.Done()
-	defer func() {
-		s.mu.Lock()
-		if c, exists := s.clients[clientID]; exists {
-			close(c.messageChan)
-			delete(s.clients, clientID)
-		}
-		s.mu.Unlock()
-	}()
-
-	// Send initial endpoint event
-	endpoint := fmt.Sprintf("%s?sessionId=%s", "/messages", sessionID)
-	if _, err := fmt.Fprintf(w, "event: endpoint\ndata: %s\n\n", endpoint); err != nil {
-		s.logger.Error().Err(err).Msg("Failed to write endpoint event")
-		return
-	}
-	w.(http.Flusher).Flush()
+	defer s.removeClient(clientID)
+	defer close(client.messageChan)
 
 	for {
 		select {
-		case msg := <-client.messageChan:
-			if msg == nil {
-				return
+		case <-ctx.Done():
+			client.logger.Info().Msg("Client disconnected (context cancelled)")
+			return
+		case <-r.Context().Done():
+			client.logger.Info().Msg("Client disconnected (request context done)")
+			return
+		case msg, ok := <-client.messageChan:
+			if !ok {
+				client.logger.Info().Msg("Client message channel closed")
+				return // Channel closed
 			}
 
-			data, err := json.Marshal(msg)
+			jsonData, err := json.Marshal(msg)
 			if err != nil {
-				s.logger.Error().Err(err).Interface("message", msg).Msg("Failed to marshal message")
+				client.logger.Error().Err(err).Msg("Failed to marshal response")
 				continue
 			}
 
-			if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data); err != nil {
-				s.logger.Error().Err(err).Msg("Failed to write message event")
-				return
+			// SSE format: data: <json string>\n\n
+			_, err = fmt.Fprintf(w, "data: %s\n\n", jsonData)
+			if err != nil {
+				client.logger.Error().Err(err).Msg("Failed to write response")
+				continue
 			}
-			w.(http.Flusher).Flush()
-
-		case <-ctx.Done():
-			return
+			flusher.Flush() // Ensure data is sent immediately
+			client.logger.Debug().RawJSON("data", jsonData).Msg("Sent message via SSE")
 		}
 	}
 }
 
 func (s *SSETransport) handleMessages(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	s.mu.RLock()
+	if s.handler == nil {
+		s.mu.RUnlock()
+		s.logger.Error().Msg("Handler not set")
+		http.Error(w, "Server not ready", http.StatusInternalServerError)
+		return
+	}
+	if s.sessionStore == nil {
+		s.mu.RUnlock()
+		s.logger.Error().Msg("Session store not set")
+		http.Error(w, "Server configuration error", http.StatusInternalServerError)
+		return
+	}
+	s.mu.RUnlock() // Unlock early
 
+	// Handle CORS preflight requests
 	if r.Method == "OPTIONS" {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization") // Add headers you expect
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	sessionID := r.URL.Query().Get("sessionId")
-	if sessionID == "" {
-		sessionID = "default"
-	}
+	w.Header().Set("Access-Control-Allow-Origin", "*") // Allow CORS for actual requests
 
-	ctx := context.WithValue(r.Context(), sessionIDKey, sessionID)
+	// Get session and enhance context
+	currentSession, sessionID := s.getSessionFromRequest(r)
+	if currentSession == nil {
+		// This path might occur if a /messages POST happens before /sse GET
+		currentSession = s.sessionStore.Create()
+		sessionID = currentSession.ID
+		s.logger.Info().Str("session_id", string(sessionID)).Msg("Created new session via /messages")
+		// Important: Need to set the cookie in the response here too!
+		s.setSessionCookie(w, sessionID)
+	}
+	ctx := session.WithSession(r.Context(), currentSession)
+
+	// Create a scoped logger for this request
+	reqLogger := s.logger.With().Str("session_id", string(sessionID)).Logger()
 
 	var request protocol.Request
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		s.logger.Error().Err(err).Msg("Failed to decode request")
-		w.WriteHeader(http.StatusBadRequest)
+		reqLogger.Error().Err(err).Msg("Failed to decode request")
+		// Send JSON-RPC error response for parse error
+		errResp := transport.NewParseError(fmt.Sprintf("Failed to decode request: %v", err))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest) // Use 400 for parse errors
+		err = json.NewEncoder(w).Encode(errResp)
+		if err != nil {
+			reqLogger.Error().Err(err).Msg("Failed to encode error response")
+		}
 		return
 	}
 
+	reqLogger = reqLogger.With().Str("method", request.Method).Logger()
+	reqLogger.Info().RawJSON("params", request.Params).Msg("Received message via POST")
+
+	// Handle notifications (no response expected, but acknowledge receipt)
+	if transport.IsNotification(&request) {
+		notif := &protocol.Notification{
+			JSONRPC: request.JSONRPC,
+			Method:  request.Method,
+			Params:  request.Params,
+		}
+		err := s.handler.HandleNotification(ctx, notif)
+		if err != nil {
+			reqLogger.Error().Err(err).Msg("Error handling notification")
+			// Do not send error response for notifications per JSON-RPC spec
+		}
+		w.WriteHeader(http.StatusNoContent) // Acknowledge receipt
+		return
+	}
+
+	// Handle regular requests
 	response, err := s.handler.HandleRequest(ctx, &request)
 	if err != nil {
-		s.logger.Error().Err(err).Msg("Error handling request")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	if response != nil {
-		if err := s.Send(ctx, response); err != nil {
-			s.logger.Error().Err(err).Msg("Error sending response")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+		reqLogger.Error().Err(err).Msg("Error handling request")
+		// Convert handler error to JSON-RPC error
+		jsonRPCError := transport.ProcessError(err)
+		response = &protocol.Response{
+			JSONRPC: "2.0",
+			ID:      request.ID, // Echo the original request ID
+			Error:   jsonRPCError,
 		}
 	}
 
-	w.WriteHeader(http.StatusAccepted)
+	if response != nil {
+		w.Header().Set("Content-Type", "application/json")
+		if response.Error != nil {
+			// Determine appropriate HTTP status code from JSON-RPC error code
+			statusCode := transport.ErrorToHTTPStatus(response.Error.Code)
+			w.WriteHeader(statusCode)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			reqLogger.Error().Err(err).Msg("Failed to encode response")
+			// Don't try to write again if encoding fails
+			return
+		}
+		reqLogger.Debug().
+			RawJSON("response", response.Result).
+			Interface("error", response.Error).
+			Msg("Sent response via POST")
+	} else {
+		// Should not happen for non-notifications, but handle defensively
+		reqLogger.Warn().Msg("Handler returned nil response for non-notification request")
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// getSessionFromRequest retrieves the session ID from the cookie or creates a new session.
+// It ensures the session exists in the store.
+func (s *SSETransport) getSessionFromRequest(r *http.Request) (*session.Session, session.SessionID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.sessionStore == nil {
+		s.logger.Error().Msg("Session store is nil in getSessionFromRequest")
+		// Return a transient session? This indicates a severe configuration error.
+		// For now, let's create one on the fly, but log heavily.
+		panic("Session store not initialized in SSE transport") // Or handle more gracefully
+	}
+
+	cookie, err := r.Cookie(SessionCookieName)
+	var sessionID string
+	var currentSession *session.Session
+	foundInStore := false
+
+	if err == nil && cookie.Value != "" {
+		sessionID = cookie.Value
+		currentSession, foundInStore = s.sessionStore.Get(session.SessionID(sessionID))
+		sessionLogger := s.logger.With().Str("session_id", sessionID).Logger()
+		if foundInStore {
+			sessionLogger.Debug().Msg("Retrieved existing session from store")
+		} else {
+			sessionLogger.Warn().Msg("Session ID from cookie not found in store, creating new session")
+		}
+	}
+
+	// If no valid cookie, or session not found in store, create a new one
+	if !foundInStore {
+		currentSession = s.sessionStore.Create()
+		sessionID = string(currentSession.ID)
+		s.logger.Info().Str("session_id", sessionID).Msg("Created new session")
+	}
+
+	return currentSession, session.SessionID(sessionID)
+}
+
+// setSessionCookie sets the session ID cookie in the HTTP response.
+func (s *SSETransport) setSessionCookie(w http.ResponseWriter, sessionID session.SessionID) {
+	cookie := http.Cookie{
+		Name:     SessionCookieName,
+		Value:    string(sessionID),
+		Path:     "/", // Cookie is valid for all paths
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode, // Consider Strict if applicable
+		// Secure: true, // Enable this if served over HTTPS
+		// MaxAge: 3600 * 24 * 7, // Example: 1 week expiry
+	}
+	http.SetCookie(w, &cookie)
+}
+
+func (s *SSETransport) removeClient(clientID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	client, ok := s.clients[clientID]
+	if !ok {
+		return // Client already removed
+	}
+
+	sessionID := client.sessionID
+	delete(s.clients, clientID)
+
+	// Remove client from session list
+	if sessionClients, sessionExists := s.sessions[sessionID]; sessionExists {
+		newSessionClients := make([]*SSEClient, 0, len(sessionClients)-1)
+		for _, c := range sessionClients {
+			if c.id != clientID {
+				newSessionClients = append(newSessionClients, c)
+			}
+		}
+		// If the session is now empty, remove it
+		if len(newSessionClients) == 0 {
+			delete(s.sessions, sessionID)
+			client.logger.Info().Msg("Session closed (last client disconnected)")
+		} else {
+			s.sessions[sessionID] = newSessionClients
+		}
+	}
+
+	client.logger.Info().Msg("Client removed")
+}
+
+// SetSessionStore implements the transport.Transport interface
+func (s *SSETransport) SetSessionStore(store session.SessionStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessionStore = store
+	s.logger.Info().Msg("Session store set for SSE transport")
 }

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-go-golems/go-go-mcp/pkg/protocol"
+	"github.com/go-go-golems/go-go-mcp/pkg/session"
 )
 
 // Transport handles the low-level communication between client and server
@@ -20,6 +21,9 @@ type Transport interface {
 
 	// Info returns metadata about the transport
 	Info() TransportInfo
+
+	// SetSessionStore provides the session store to the transport layer
+	SetSessionStore(store session.SessionStore)
 }
 
 // TransportInfo provides metadata about the transport

--- a/ttmp/2025-05-03/01-design-for-passing-context-session-information-to-handlers.md
+++ b/ttmp/2025-05-03/01-design-for-passing-context-session-information-to-handlers.md
@@ -1,0 +1,111 @@
+# Design for Passing Session Information through Context in MCP
+
+## Overview
+
+This document outlines a design for adding session state management to the Model Context Protocol (MCP) implementation. The goal is to enable the MCP server to maintain state throughout a client session by passing a sessionId and sessionState through the context object.
+
+## Components Involved
+
+### Core Files
+
+1.  `pkg/server/server.go`: Server structure and lifecycle management.
+2.  `pkg/server/handler.go`: Request routing and base handling.
+3.  `pkg/server/options.go`: Server configuration options.
+4.  `pkg/session/session.go`: Session types and context utilities.
+5.  `pkg/session/store.go`: SessionStore interface and InMemorySessionStore implementation.
+6.  `pkg/transport/transport.go`: Transport interface definition.
+7.  `pkg/transport/sse/transport.go`: SSE transport implementation.
+8.  `pkg/transport/stdio/transport.go`: Stdio transport implementation.
+9.  `pkg/providers.go`: Provider interface definitions.
+10. `pkg/tools/providers/tool-registry/registry.go`: Example ToolProvider implementation.
+
+## Design Approach
+
+1.  **Create Session Package (`pkg/session`)**: Centralize session-related types (`Session`, `SessionState`), storage interface (`SessionStore`), an in-memory implementation (`InMemorySessionStore`), and context utilities (`WithSession`, `GetSessionFromContext`).
+2.  **Integrate SessionStore into Server**: Add `sessionStore` field to `Server` struct, provide `WithSessionStore` option, and initialize a default `InMemorySessionStore` in `NewServer`.
+3.  **Modify Transport Interface**: Add `SetSessionStore(store session.SessionStore)` method to `transport.Transport` interface.
+4.  **Inject SessionStore into Transports**: Call `transport.SetSessionStore` in `Server.Start` to pass the configured store to the active transport.
+5.  **Implement Session Handling in Transports**:
+    *   **SSE (`pkg/transport/sse/transport.go`)**:
+        *   Implement `SetSessionStore`.
+        *   Use HTTP cookies (`mcp_session_id`) for session identification (`getSessionFromRequest`, `setSessionCookie`).
+        *   Retrieve existing or create new sessions using the `SessionStore`.
+        *   Enhance the request context using `session.WithSession` in `handleSSE` and `handleMessages` before passing it to the `RequestHandler`.
+    *   **Stdio (`pkg/transport/stdio/transport.go`)**:
+        *   Implement `SetSessionStore`.
+        *   Maintain a single `currentSession` per connection.
+        *   Create a new session via `SessionStore` upon receiving an `initialize` request (or implicitly on the first request if not `initialize`) using the `manageSession` helper.
+        *   Enhance the context using `session.WithSession` in the message reading loop before passing it to the `RequestHandler`.
+6.  **Utilize Session Context in Handler**: The `RequestHandler` methods receive the session-enhanced context from the transport layer. `handleInitialize` was updated to log the session ID and potentially include it in the response (protocol spec dependent). Other handlers pass the context downstream to providers.
+7.  **Provider/Tool Access**: Providers and tools can retrieve the session from the context using `session.GetSessionFromContext(ctx)` if they need access to session state.
+
+## Implementation Details (Summary)
+
+### Session Management Package (`pkg/session`)
+
+*   **Types**: `Session`, `SessionState` defined in `session.go`.
+*   **Store**: `SessionStore` interface and `InMemorySessionStore` implementation in `store.go`. Uses `sync.RWMutex` for thread safety.
+*   **Context Utilities**: `WithSession` and `GetSessionFromContext` in `session.go` using an unexported `contextKey`.
+
+### Server Modifications (`pkg/server`)
+
+*   `Server` struct in `server.go` now includes `sessionStore session.SessionStore`.
+*   `NewServer` in `server.go` initializes `sessionStore` with `session.NewInMemorySessionStore()`.
+*   `WithSessionStore` option added in `options.go`.
+*   `Server.Start` in `server.go` calls `s.transport.SetSessionStore(s.sessionStore)`.
+
+### Transport Modifications (`pkg/transport`)
+
+*   `Transport` interface in `transport.go` includes `SetSessionStore(store session.SessionStore)`.
+*   **SSE (`sse/transport.go`)**:
+    *   Implements `SetSessionStore`.
+    *   Adds `sessionStore` field.
+    *   Uses `getSessionFromRequest` (checks cookie `mcp_session_id`, interacts with `sessionStore`) and `setSessionCookie`.
+    *   Calls `session.WithSession(r.Context(), currentSession)` in handlers.
+    *   Manages client-to-session mapping (`clients`, `sessions` maps).
+*   **Stdio (`stdio/transport.go`)**:
+    *   Implements `SetSessionStore`.
+    *   Adds `sessionStore` and `currentSession` fields.
+    *   Uses `manageSession` helper (checks for `initialize` method, interacts with `sessionStore`).
+    *   Calls `session.WithSession(baseCtx, s.currentSession)` in the read loop.
+
+### Request Handler Modifications (`pkg/server/handler.go`)
+
+*   `handleInitialize` now uses `session.GetSessionFromContext(ctx)` to retrieve the session passed by the transport and logs its ID. It was also updated to potentially add the session ID to the `InitializeResult`.
+*   Other handlers (`handlePromptsList`, `handleToolsCall`, etc.) receive the enhanced context and pass it to providers.
+
+## Function Flow (Updated)
+
+1.  Client connects (SSE establishes HTTP connection, Stdio starts).
+2.  **Transport Layer**:
+    *   Receives request (`handleSSE`/`handleMessages` for SSE, read loop for Stdio).
+    *   **Identifies/Creates Session**:
+        *   SSE: Checks `mcp_session_id` cookie, uses `sessionStore.Get` or `sessionStore.Create`. Sets cookie in response.
+        *   Stdio: Checks if `initialize` request or if `currentSession` is nil, uses `sessionStore.Create` via `manageSession`.
+    *   **Enhances Context**: Calls `session.WithSession(ctx, currentSession)`.
+    *   Passes request and *enhanced context* to `RequestHandler`.
+3.  `RequestHandler.HandleRequest(ctx, req)`:
+    *   Receives enhanced context.
+    *   Routes to specific handler (e.g., `handleInitialize`, `handleToolsCall`) based on `req.Method`, passing the enhanced context.
+4.  Method-specific handler (e.g., `handleInitialize`, `handleToolsCall`):
+    *   Operates using the enhanced context.
+    *   `handleInitialize` logs session ID from context.
+    *   Other handlers call provider methods, passing the enhanced context.
+5.  Provider implementation (e.g., `Registry.CallTool`):
+    *   Receives enhanced context.
+    *   **Can optionally** access session info using `session.GetSessionFromContext(ctx)`.
+    *   Passes context to tool handler or `tool.Call`.
+6.  Tool implementation:
+    *   Receives context.
+    *   **Can optionally** access session info using `session.GetSessionFromContext(ctx)`.
+
+## Considerations
+
+1.  **Concurrency**: `InMemorySessionStore` uses `sync.RWMutex`. Ensure any custom stores or direct access to `Session.State` is thread-safe.
+2.  **Session Lifetime**: `InMemorySessionStore` currently has no expiration. A cleanup mechanism (e.g., background ticker checking `LastAccessTime`) should be added for production use, especially for SSE. Stdio sessions implicitly end with the connection unless explicitly persisted.
+3.  **Session Identification**:
+    *   SSE relies on the `mcp_session_id` HTTP cookie. Security attributes (Secure, HttpOnly, SameSite) are set.
+    *   Stdio manages one session per connection, reset by `initialize`.
+4.  **State Size**: No limits currently enforced on `SessionState` size. Consider adding limits or using external stores for large states.
+5.  **Persistence**: `InMemorySessionStore` is not persistent. Implementations requiring persistence need a different `SessionStore` (e.g., Redis, database).
+6.  **Error Handling**: Added `transport.ProcessError` and `transport.ErrorToHTTPStatus` for better error reporting. 

--- a/ttmp/2025-05-03/02-design-and-architecture-and-control-flow-of-go-go-mcp.md
+++ b/ttmp/2025-05-03/02-design-and-architecture-and-control-flow-of-go-go-mcp.md
@@ -1,0 +1,287 @@
+# Design, Architecture, and Control Flow of go-go-mcp
+
+## Overview
+
+This document outlines the design, architecture, and request flow of go-go-mcp, a Go implementation of the Model Context Protocol (MCP) server that exposes RPC-like capabilities. The server enables **session state management** and communication between clients and server through different transport mechanisms (SSE, stdio).
+
+## Architectural Components
+
+### Core Components
+
+1. **Server**: Manages the lifecycle of the MCP server, holds provider and **session store** references, and coordinates request processing.
+2. **Transports**: Handles communication protocols (HTTP/SSE, stdio) between clients and the server. **Responsible for session identification and context enhancement.**
+3. **RequestHandler**: Processes incoming requests (with session context) and dispatches them to appropriate method handlers.
+4. **Providers**: Interfaces for serving prompts, resources, and tools. Receive session context.
+5. **Tools**: Implementations of various tools that can be invoked via the MCP protocol. Receive session context.
+6. **Session Management**: Handles session creation, storage (`SessionStore`), and context propagation (`pkg/session`).
+
+### Key Files and Packages
+
+1. **Server Package (`pkg/server/`)**
+   - `server.go`: Main server implementation (holds `SessionStore`).
+   - `handler.go`: Request handling and routing (uses session context).
+   - `options.go`: Server configuration options (includes `WithSessionStore`).
+
+2. **Session Package (`pkg/session/`)**
+   - `session.go`: `Session`, `SessionState` types; `WithSession`, `GetSessionFromContext` utilities.
+   - `store.go`: `SessionStore` interface, `InMemorySessionStore` implementation.
+
+3. **Transport Package (`pkg/transport/`)**
+   - `transport.go`: Common `Transport` interface (includes `SetSessionStore`), `RequestHandler` interface.
+   - `errors.go`: Common error types for MCP, `ProcessError`, `ErrorToHTTPStatus` helpers.
+   - `options.go`: Transport configuration options.
+   - `sse/transport.go`: Server-Sent Events transport implementation (handles cookie-based sessions).
+   - `stdio/transport.go`: Standard I/O transport implementation (handles connection-based sessions).
+
+4. **Protocol Package (`pkg/protocol/`)**
+   - Contains message types and protocol definitions.
+
+5. **Provider Interfaces (`pkg/providers.go`)**
+   - Defines interfaces for PromptProvider, ResourceProvider, and ToolProvider (methods accept `context.Context`).
+
+6. **Tool Registry (`pkg/tools/providers/tool-registry/registry.go`)**
+   - Registry for tool registration and invocation (methods accept `context.Context`).
+
+7. **Command Package (`cmd/go-go-mcp/`)**
+   - `main.go`: Application entry point.
+   - `cmds/server/start.go`: Server startup logic.
+
+## Initialization Flow
+
+The initialization flow of the MCP server starts in `cmd/go-go-mcp/cmds/server/start.go` and proceeds as follows:
+
+1. **Transport Creation**:
+   ```go
+   // Create transport based on type
+   var t transport.Transport
+   switch transportType {
+   case "sse":
+     t, err = sse.NewSSETransport(
+       transport.WithLogger(logger),
+       transport.WithSSEOptions(transport.SSEOptions{
+         Addr: fmt.Sprintf(":%d", port),
+       }),
+     )
+   case "stdio":
+     t, err = stdio.NewStdioTransport(
+       transport.WithLogger(logger),
+     )
+   }
+   ```
+
+2. **Provider Creation**:
+   ```go
+   // Create tool provider
+   configToolProvider, err := layers.CreateToolProvider(serverSettings)
+   
+   // Initialize the final tool provider
+   var toolProvider pkg.ToolProvider = configToolProvider
+   
+   // Register internal servers if specified
+   if len(s_.InternalServers) > 0 {
+     registry := tool_registry.NewRegistry()
+     
+     // Register the internal servers
+     if err := registerInternalServers(registry, s_.InternalServers); err != nil {
+       return err
+     }
+     
+     // Combine the registry with the config tool provider
+     toolProvider = tools.CombineProviders(configToolProvider, registry)
+   }
+   
+   // Create resource provider
+   resourceProvider := resources.NewRegistry()
+   ```
+
+3. **Server Creation**:
+   ```go
+   // Create server with transport, providers, and potentially session store option
+   s := server.NewServer(logger, t,
+     server.WithToolProvider(toolProvider),
+     server.WithResourceProvider(resourceProvider),
+     // Optionally: server.WithSessionStore(customSessionStore),
+   )
+   // NewServer initializes a default InMemorySessionStore if none is provided.
+   ```
+
+4. **Server Start**:
+   ```go
+   // Start server in a goroutine
+   g.Go(func() error {
+     defer cancel()
+     // Server.Start injects the session store into the transport
+     // via transport.SetSessionStore()
+     if err := s.Start(gctx); err != nil && err != io.EOF {
+       logger.Error().Err(err).Msg("Server error")
+       return err
+     }
+     return nil
+   })
+   ```
+
+## Request Processing Flow (with Session Management)
+
+The request processing flow in the MCP server follows these steps:
+
+1. **Request Reception (Transport Layer)**:
+   - `SSETransport` (`handleSSE`, `handleMessages`) or `StdioTransport` (read loop) receives the raw request.
+
+2. **Session Identification & Context Enhancement (Transport Layer)**:
+   - **SSE**: `getSessionFromRequest` retrieves/creates a session using the `SessionStore` based on the `mcp_session_id` cookie. `setSessionCookie` is called. Context is enhanced: `ctx := session.WithSession(r.Context(), currentSession)`.
+   - **Stdio**: `manageSession` retrieves/creates the `currentSession` for the connection (new session on `initialize`). Context is enhanced: `ctx := session.WithSession(baseCtx, s.currentSession)`.
+
+3. **Forward to Handler (Transport Layer)**:
+   - The transport calls `s.handler.HandleRequest(ctx, &request)` or `s.handler.HandleNotification(ctx, &notification)`, passing the **session-enhanced context**.
+
+4. **Request Routing (`RequestHandler`)**:
+   - `RequestHandler.HandleRequest` in `pkg/server/handler.go` receives the enhanced context.
+   - It validates the request and routes it based on the method to a specific handler (e.g., `handleInitialize`), passing the **enhanced context** along.
+
+5. **Method Handler Processing (`RequestHandler`)**:
+   - Each method-specific handler (e.g., `handleInitialize`, `handleToolsCall`) receives the **enhanced context**.
+   - `handleInitialize` retrieves the session from the context using `session.GetSessionFromContext` and logs the ID.
+   - Parameters are extracted.
+   - Provider methods are called with the **enhanced context**.
+
+6. **Provider Invocation (Providers)**:
+   - Provider methods (e.g., `ToolProvider.CallTool`) receive the **enhanced context**.
+   - They can optionally access session data: `s, ok := session.GetSessionFromContext(ctx)`.
+   - They execute their logic and return results.
+
+7. **Response Creation (`RequestHandler`)**:
+   - The handler creates a success response (`newSuccessResponse`). `handleInitialize` adds the SessionID to the result.
+
+8. **Response Transmission (Transport Layer)**:
+   - The response is sent back via the appropriate transport mechanism (SSE client channel or stdio writer).
+
+## Session Handling (Implementation Details)
+
+Session state is managed primarily within the transport layer, leveraging the `pkg/session` package.
+
+### Session Package (`pkg/session`)
+
+- Provides `Session`, `SessionState`, `SessionStore`, `InMemorySessionStore`.
+- Provides context utilities: `WithSession(ctx, session)` and `GetSessionFromContext(ctx)`. `InMemorySessionStore` uses `sync.RWMutex`.
+
+### Server Integration
+
+- `Server` holds a `sessionStore session.SessionStore`.
+- `NewServer` creates a default `InMemorySessionStore`.
+- `WithSessionStore` allows injecting custom stores.
+- `Server.Start` calls `transport.SetSessionStore` to pass the store to the active transport.
+
+### SSE Transport Session Handling (`pkg/transport/sse/transport.go`)
+
+- Implements `SetSessionStore` and holds a `sessionStore` field.
+- Uses `http.Cookie` named `mcp_session_id`.
+- `getSessionFromRequest(r)`:
+  - Reads cookie.
+  - Calls `sessionStore.Get()` or `sessionStore.Create()`.
+  - Returns `(*session.Session, string)`.
+- `setSessionCookie(w, sessionID)`: Sets the cookie in the response header.
+- `handleSSE` & `handleMessages`:
+  - Call `getSessionFromRequest`.
+  - Call `setSessionCookie`.
+  - Enhance context: `ctx := session.WithSession(r.Context(), currentSession)`.
+  - Call `handler.HandleRequest/HandleNotification` with the enhanced `ctx`.
+- Maintains maps `clients` (clientID -> client) and `sessions` (sessionID -> []*SSEClient) for message routing.
+
+### Stdio Transport Session Handling (`pkg/transport/stdio/transport.go`)
+
+- Implements `SetSessionStore` and holds `sessionStore` and `currentSession *session.Session` fields.
+- `manageSession(baseCtx, req)`:
+  - Checks if `req.Method == "initialize"` or `s.currentSession == nil`.
+  - Calls `sessionStore.Create()` to get/replace `s.currentSession`.
+  - Returns `session.WithSession(baseCtx, s.currentSession)`.
+- Message Read Loop:
+  - Parses request.
+  - Calls `ctx := s.manageSession(scannerCtx, &request)`.
+  - Calls `s.handleMessage(ctx, &request)` with the enhanced `ctx`.
+- `handleRequest`/`handleNotification` pass the enhanced `ctx` to the main `RequestHandler`.
+
+## Tool Registry and Invocation
+
+1. **Tool Registration**:
+   ```go
+   func (r *Registry) RegisterTool(tool tools.Tool) {
+     r.mu.Lock()
+     defer r.mu.Unlock()
+     r.tools[tool.GetName()] = tool
+   }
+   ```
+
+2. **Tool Listing**:
+   ```go
+   func (r *Registry) ListTools(_ context.Context, cursor string) ([]protocol.Tool, string, error) {
+     r.mu.RLock()
+     defer r.mu.RUnlock()
+     
+     tools := make([]protocol.Tool, 0, len(r.tools))
+     for _, t := range r.tools {
+       tools = append(tools, t.GetToolDefinition())
+     }
+     // ...
+   }
+   ```
+
+3. **Tool Invocation**:
+   ```go
+   func (r *Registry) CallTool(ctx context.Context, name string, arguments map[string]interface{}) (*protocol.ToolResult, error) {
+     r.mu.RLock()
+     defer r.mu.RUnlock()
+     
+     tool, ok := r.tools[name]
+     if !ok {
+       return nil, pkg.ErrToolNotFound
+     }
+     
+     if handler, ok := r.handlers[name]; ok {
+       return handler(ctx, tool, arguments)
+     }
+     
+     // If no handler is registered, use the tool's Call method
+     return tool.Call(ctx, arguments)
+   }
+   ```
+
+## Shutdown Flow
+
+The server shutdown flow handles graceful termination:
+
+1. **Signal Handling**:
+   ```go
+   ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+   defer stop()
+   ```
+
+2. **Graceful Shutdown**:
+   ```go
+   g.Go(func() error {
+     <-gctx.Done()
+     logger.Info().Msg("Initiating graceful shutdown")
+     shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+     defer shutdownCancel()
+     if err := s.Stop(shutdownCtx); err != nil {
+       logger.Error().Err(err).Msg("Error during shutdown")
+       return err
+     }
+     logger.Info().Msg("Server stopped gracefully")
+     return nil
+   })
+   ```
+
+3. **Transport Cleanup**:
+   - For SSE, clients are notified and connections closed.
+   - For stdio, ongoing operations are cancelled.
+
+## Conclusion
+
+The go-go-mcp server now incorporates session management:
+
+- **Centralized Session Logic**: `pkg/session` provides core types and context utilities.
+- **Transport-Specific Handling**: SSE uses cookies, Stdio uses connection state, both managed within their respective transport implementations.
+- **Context Propagation**: Session information is consistently passed down the call stack via `context.Context`.
+- **Flexible Storage**: Supports `InMemorySessionStore` by default, with the ability to inject custom persistent stores via `WithSessionStore`.
+
+This enables stateful interactions within the MCP framework, allowing tools and providers to access session-specific data when needed. 


### PR DESCRIPTION
This PR introduces session management to the MCP server and refactors the SQLite 
tools to leverage sessions for database connections.

## Session Management
* Add new `pkg/session` package with session state management
* Implement thread-safe `Session` and `SessionState` types
* Create `SessionStore` interface with `InMemorySessionStore` implementation
* Add context utilities for session propagation (`WithSession`, `GetSessionFromContext`)
* Integrate session store with Server and transport layers
* Enhance error handling with `ProcessError` and `ErrorToHTTPStatus`

## Transport Enhancements
* Update SSE transport to use cookie-based session tracking
* Update stdio transport to maintain session per connection
* Add `SetSessionStore` method to Transport interface
* Improve context propagation through request handling chain

## SQLite Tool Improvements
* Replace single SQLite tool with modular approach:
  * `sqlite_open`: Opens and stores DB connection in session
  * `sqlite_query`: Uses session DB or opens temporary connection
* Add CSV output format option with improved formatting
* Implement query type detection (SELECT, DML, admin commands)
* Add result size limits and row count limits
* Improve error handling and reporting
* Add better query metadata (rows affected, warnings for zero rows)

## Documentation
* Add detailed design docs explaining session architecture
* Document control flow and component interactions

BREAKING CHANGE: The SQLite tool API has changed. The previous 
`sqlite` tool is replaced with separate `sqlite_open` and `sqlite_query` tools.