### PR TITLE
Add profile management to TUI

### DIFF
--- a/cmd/go-go-mcp/cmds/config.go
+++ b/cmd/go-go-mcp/cmds/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/go-go-golems/go-go-mcp/pkg/config"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -63,6 +64,7 @@ func NewConfigGroupCommand() *cobra.Command {
 	cmd.AddCommand(NewConfigAddProfileCommand())
 	cmd.AddCommand(NewConfigDuplicateProfileCommand())
 	cmd.AddCommand(NewConfigSetDefaultProfileCommand())
+	// UI command already exists in ui_cmd.go and ui_command.go
 
 	return cmd
 }
@@ -224,7 +226,7 @@ func NewConfigListProfilesCommand() *cobra.Command {
 
 			defaultProfile, err := editor.GetDefaultProfile()
 			if err != nil {
-				return fmt.Errorf("could not get default profile: %w", err)
+				log.Warn().Msgf("could not get default profile: %v", err)
 			}
 
 			profiles, err := editor.GetProfiles()
@@ -422,3 +424,5 @@ func NewConfigSetDefaultProfileCommand() *cobra.Command {
 		},
 	}
 }
+
+// Using existing UI command instead

--- a/pkg/config/editor.go
+++ b/pkg/config/editor.go
@@ -149,6 +149,83 @@ func (c *ConfigEditor) AddToolFile(profile, path string) error {
 	return nil
 }
 
+// AddPromptDirectory adds a prompt directory to a profile
+func (c *ConfigEditor) AddPromptDirectory(profile, path string, defaults map[string]interface{}) error {
+	// Create the directory source node
+	dirNode, err := c.editor.CreateMap(
+		"path", path,
+		"defaults", map[string]interface{}{
+			"default": defaults,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("could not create directory node: %w", err)
+	}
+
+	// Get the prompts node
+	promptsNode, err := c.editor.GetNode("profiles", profile, "prompts")
+	if err != nil {
+		return fmt.Errorf("could not get prompts node: %w", err)
+	}
+
+	// Get or create the directories sequence
+	var dirSeqNode *yaml.Node
+	_, err = c.editor.GetMapNode("directories", promptsNode)
+	if err != nil {
+		// Create new directories sequence
+		dirSeqNode = &yaml.Node{Kind: yaml.SequenceNode}
+		err = c.editor.SetNode(dirSeqNode, "profiles", profile, "prompts", "directories")
+		if err != nil {
+			return fmt.Errorf("could not create directories sequence: %w", err)
+		}
+	}
+
+	// Append the new directory
+	err = c.editor.AppendToSequence(dirNode, "profiles", profile, "prompts", "directories")
+	if err != nil {
+		return fmt.Errorf("could not append directory: %w", err)
+	}
+
+	return nil
+}
+
+// AddPromptFile adds a prompt file to a profile
+func (c *ConfigEditor) AddPromptFile(profile, path string) error {
+	// Create the file source node
+	fileNode, err := c.editor.CreateMap(
+		"path", path,
+	)
+	if err != nil {
+		return fmt.Errorf("could not create file node: %w", err)
+	}
+
+	// Get the prompts node
+	promptsNode, err := c.editor.GetNode("profiles", profile, "prompts")
+	if err != nil {
+		return fmt.Errorf("could not get prompts node: %w", err)
+	}
+
+	// Get or create the files sequence
+	var fileSeqNode *yaml.Node
+	_, err = c.editor.GetMapNode("files", promptsNode)
+	if err != nil {
+		// Create new files sequence
+		fileSeqNode = &yaml.Node{Kind: yaml.SequenceNode}
+		err = c.editor.SetNode(fileSeqNode, "profiles", profile, "prompts", "files")
+		if err != nil {
+			return fmt.Errorf("could not create files sequence: %w", err)
+		}
+	}
+
+	// Append the new file
+	err = c.editor.AppendToSequence(fileNode, "profiles", profile, "prompts", "files")
+	if err != nil {
+		return fmt.Errorf("could not append file: %w", err)
+	}
+
+	return nil
+}
+
 func (c *ConfigEditor) SetDefaultProfile(profile string) error {
 	// Create a scalar node with the profile name
 	profileNode := &yaml.Node{
@@ -200,4 +277,51 @@ func (c *ConfigEditor) GetDefaultProfile() (string, error) {
 	}
 
 	return node.Value, nil
+}
+
+// DeleteNode removes a node from a mapping node by its key
+func (c *ConfigEditor) DeleteNode(parent *yaml.Node, key string) error {
+	if parent.Kind != yaml.MappingNode {
+		return fmt.Errorf("parent node is not a mapping node")
+	}
+
+	// Find the key in the mapping
+	for i := 0; i < len(parent.Content); i += 2 {
+		if parent.Content[i].Value == key {
+			// Remove the key-value pair (2 nodes)
+			parent.Content = append(parent.Content[:i], parent.Content[i+2:]...)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("key %s not found in mapping", key)
+}
+
+// DeleteProfile removes a profile from the configuration
+func (c *ConfigEditor) DeleteProfile(name string) error {
+	// Check if the profile exists first
+	_, err := c.GetProfile(name)
+	if err != nil {
+		return fmt.Errorf("profile %s not found: %w", name, err)
+	}
+
+	// Get the default profile to prevent deleting it
+	defaultProfile, err := c.GetDefaultProfile()
+	if err == nil && defaultProfile == name {
+		return fmt.Errorf("cannot delete the default profile, please change the default profile first")
+	}
+
+	// Get the profiles node
+	profilesNode, err := c.editor.GetNode("profiles")
+	if err != nil {
+		return fmt.Errorf("could not get profiles node: %w", err)
+	}
+
+	// Use our helper method to delete the profile node
+	err = c.DeleteNode(profilesNode, name)
+	if err != nil {
+		return fmt.Errorf("could not delete profile %s: %w", name, err)
+	}
+
+	return nil
 }

--- a/pkg/ui/tui/confirm.go
+++ b/pkg/ui/tui/confirm.go
@@ -34,20 +34,34 @@ var defaultConfirmKeyMap = confirmKeyMap{
 
 // ConfirmModel represents a confirmation dialog
 type ConfirmModel struct {
-	title    string
-	message  string
-	selected bool // true = yes, false = no
-	keyMap   confirmKeyMap
+	title     string
+	message   string
+	selected  bool // true = yes, false = no
+	keyMap    confirmKeyMap
+	confirmed bool // Whether confirm was selected
+	cancelled bool // Whether cancel was selected
 }
 
 // NewConfirmModel creates a new confirmation dialog
 func NewConfirmModel(title, message string) ConfirmModel {
 	return ConfirmModel{
-		title:    title,
-		message:  message,
-		selected: false,
-		keyMap:   defaultConfirmKeyMap,
+		title:     title,
+		message:   message,
+		selected:  false,
+		keyMap:    defaultConfirmKeyMap,
+		confirmed: false,
+		cancelled: false,
 	}
+}
+
+// Confirmed returns whether the dialog was confirmed
+func (m ConfirmModel) Confirmed() bool {
+	return m.confirmed && m.selected
+}
+
+// Cancelled returns whether the dialog was cancelled
+func (m ConfirmModel) Cancelled() bool {
+	return m.cancelled || (m.confirmed && !m.selected)
 }
 
 // ConfirmMsg is returned when a selection is confirmed
@@ -69,11 +83,15 @@ func (m ConfirmModel) Update(msg tea.Msg) (ConfirmModel, tea.Cmd) {
 			return m, nil
 
 		case key.Matches(msg, m.keyMap.Confirm):
+			m.confirmed = true
+			m.cancelled = false
 			return m, func() tea.Msg {
 				return ConfirmMsg{Confirmed: m.selected}
 			}
 
 		case key.Matches(msg, m.keyMap.Cancel):
+			m.confirmed = false
+			m.cancelled = true
 			return m, func() tea.Msg {
 				return ConfirmMsg{Confirmed: false}
 			}

--- a/pkg/ui/tui/profile_form.go
+++ b/pkg/ui/tui/profile_form.go
@@ -1,0 +1,331 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ProfileFormKeyMap defines keybindings specific to the profile form view
+type ProfileFormKeyMap struct {
+	Submit key.Binding
+	Cancel key.Binding
+	Next   key.Binding // Tab
+	Prev   key.Binding // Shift+Tab
+}
+
+var defaultProfileFormKeyMap = ProfileFormKeyMap{
+	Submit: key.NewBinding(
+		key.WithKeys("alt+s"),
+		key.WithHelp("alt+s", "submit"),
+	),
+	Cancel: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+	Next: key.NewBinding(
+		key.WithKeys("tab", "down"),
+		key.WithHelp("tab/↓", "next field"),
+	),
+	Prev: key.NewBinding(
+		key.WithKeys("shift+tab", "up"),
+		key.WithHelp("shift+tab/↑", "prev field"),
+	),
+}
+
+// Focus indices for the profile form fields
+const (
+	focusProfileName focusProfileField = iota
+	focusProfileDescription
+	focusToolDirs
+	focusToolFiles
+	focusPromptDirs
+	focusPromptFiles
+	focusProfileMax // Keep track of the total number of potential focus points
+)
+
+type focusProfileField int
+
+// ProfileFormModel represents the form for adding/editing profiles
+type ProfileFormModel struct {
+	keyMap           ProfileFormKeyMap
+	nameInput        textinput.Model
+	descriptionInput textinput.Model
+	toolDirsInput    textinput.Model
+	toolFilesInput   textinput.Model
+	promptDirsInput  textinput.Model
+	promptFilesInput textinput.Model
+	activeInput      focusProfileField
+	isAddMode        bool // True if adding a new profile, false if editing
+	submitted        bool // Flag indicating form submission was triggered
+	cancelled        bool // Flag indicating form cancellation was triggered
+}
+
+// NewProfileFormModel creates a new profile form model with initialized inputs
+func NewProfileFormModel() ProfileFormModel {
+	nameInput := textinput.New()
+	nameInput.Placeholder = "Profile name (required)"
+	nameInput.Focus() // Start focus on name
+	nameInput.CharLimit = 50
+	nameInput.Width = 80
+
+	descriptionInput := textinput.New()
+	descriptionInput.Placeholder = "Profile description"
+	descriptionInput.CharLimit = 200
+	descriptionInput.Width = 80
+
+	toolDirsInput := textinput.New()
+	toolDirsInput.Placeholder = "Tool directories (comma separated paths)"
+	toolDirsInput.CharLimit = 500
+	toolDirsInput.Width = 80
+
+	toolFilesInput := textinput.New()
+	toolFilesInput.Placeholder = "Tool files (comma separated paths)"
+	toolFilesInput.CharLimit = 500
+	toolFilesInput.Width = 80
+
+	promptDirsInput := textinput.New()
+	promptDirsInput.Placeholder = "Prompt directories (comma separated paths)"
+	promptDirsInput.CharLimit = 500
+	promptDirsInput.Width = 80
+
+	promptFilesInput := textinput.New()
+	promptFilesInput.Placeholder = "Prompt files (comma separated paths)"
+	promptFilesInput.CharLimit = 500
+	promptFilesInput.Width = 80
+
+	return ProfileFormModel{
+		keyMap:           defaultProfileFormKeyMap,
+		nameInput:        nameInput,
+		descriptionInput: descriptionInput,
+		toolDirsInput:    toolDirsInput,
+		toolFilesInput:   toolFilesInput,
+		promptDirsInput:  promptDirsInput,
+		promptFilesInput: promptFilesInput,
+		activeInput:      focusProfileName,
+		isAddMode:        true, // Default to add mode
+	}
+}
+
+// Update handles profile form input messages
+func (m ProfileFormModel) Update(msg tea.Msg) (ProfileFormModel, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		// Global key handling - only handle special keys like ESC, Alt+s
+		// Let other keys (like 'q') pass through to the active input
+		switch {
+		case key.Matches(msg, m.keyMap.Cancel):
+			m.cancelled = true
+			// Ensure all inputs are blurred on cancel
+			m.nameInput.Blur()
+			m.descriptionInput.Blur()
+			m.toolDirsInput.Blur()
+			m.toolFilesInput.Blur()
+			m.promptDirsInput.Blur()
+			m.promptFilesInput.Blur()
+			return m, nil
+
+		case key.Matches(msg, m.keyMap.Submit):
+			// For submit, mark as submitted and return
+			m.submitted = true
+			return m, nil
+
+		case key.Matches(msg, m.keyMap.Next), key.Matches(msg, m.keyMap.Prev):
+			direction := 1
+			if key.Matches(msg, m.keyMap.Prev) {
+				direction = -1
+			}
+
+			// Cycle through focusable elements
+			m.activeInput = (m.activeInput + focusProfileField(direction) + focusProfileMax) % focusProfileMax
+
+			cmds = append(cmds, m.updateFocus())
+			return m, tea.Batch(cmds...)
+		}
+
+		// Process the event in the active text input
+		var cmd tea.Cmd
+		switch m.activeInput {
+		case focusProfileName:
+			m.nameInput, cmd = m.nameInput.Update(msg)
+			cmds = append(cmds, cmd)
+			return m, tea.Batch(cmds...)
+		case focusProfileDescription:
+			m.descriptionInput, cmd = m.descriptionInput.Update(msg)
+			cmds = append(cmds, cmd)
+			return m, tea.Batch(cmds...)
+		case focusToolDirs:
+			m.toolDirsInput, cmd = m.toolDirsInput.Update(msg)
+			cmds = append(cmds, cmd)
+			return m, tea.Batch(cmds...)
+		case focusToolFiles:
+			m.toolFilesInput, cmd = m.toolFilesInput.Update(msg)
+			cmds = append(cmds, cmd)
+			return m, tea.Batch(cmds...)
+		case focusPromptDirs:
+			m.promptDirsInput, cmd = m.promptDirsInput.Update(msg)
+			cmds = append(cmds, cmd)
+			return m, tea.Batch(cmds...)
+		case focusPromptFiles:
+			m.promptFilesInput, cmd = m.promptFilesInput.Update(msg)
+			cmds = append(cmds, cmd)
+			return m, tea.Batch(cmds...)
+		case focusProfileMax:
+			// This should never happen as focusProfileMax is just a sentinel value
+			// Do nothing in this case
+		}
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+// updateFocus manages blurring/focusing the correct text input
+func (m *ProfileFormModel) updateFocus() tea.Cmd {
+	// Blur all inputs first
+	m.nameInput.Blur()
+	m.descriptionInput.Blur()
+	m.toolDirsInput.Blur()
+	m.toolFilesInput.Blur()
+	m.promptDirsInput.Blur()
+	m.promptFilesInput.Blur()
+
+	// Initialize command slice
+	var cmds []tea.Cmd
+
+	// Focus the correct input based on activeInput
+	switch m.activeInput {
+	case focusProfileName:
+		cmds = append(cmds, m.nameInput.Focus())
+	case focusProfileDescription:
+		cmds = append(cmds, m.descriptionInput.Focus())
+	case focusToolDirs:
+		cmds = append(cmds, m.toolDirsInput.Focus())
+	case focusToolFiles:
+		cmds = append(cmds, m.toolFilesInput.Focus())
+	case focusPromptDirs:
+		cmds = append(cmds, m.promptDirsInput.Focus())
+	case focusPromptFiles:
+		cmds = append(cmds, m.promptFilesInput.Focus())
+	case focusProfileMax:
+		// This should never happen as focusProfileMax is just a sentinel value
+		// Do nothing in this case
+	}
+
+	return tea.Batch(cmds...)
+}
+
+// View renders the profile form
+func (m ProfileFormModel) View() string {
+	var sb strings.Builder
+
+	title := "Add Profile"
+	if !m.isAddMode {
+		title = "Edit Profile"
+	}
+	sb.WriteString(title + "\n\n")
+
+	// Name Input
+	sb.WriteString(m.nameInput.View() + "\n")
+
+	// Description Input
+	sb.WriteString(m.descriptionInput.View() + "\n\n")
+
+	// Tool configuration section
+	labelStyle := lipgloss.NewStyle().Bold(true)
+	sb.WriteString(labelStyle.Render("Tools Configuration") + "\n")
+
+	// Tool directories
+	sb.WriteString(m.toolDirsInput.View() + "\n")
+
+	// Tool files
+	sb.WriteString(m.toolFilesInput.View() + "\n\n")
+
+	// Prompt configuration section
+	sb.WriteString(labelStyle.Render("Prompts Configuration") + "\n")
+
+	// Prompt directories
+	sb.WriteString(m.promptDirsInput.View() + "\n")
+
+	// Prompt files
+	sb.WriteString(m.promptFilesInput.View() + "\n")
+
+	sb.WriteString("\n")
+	sb.WriteString(m.helpView())
+
+	return sb.String()
+}
+
+// helpView renders the help text for the profile form
+func (m ProfileFormModel) helpView() string {
+	// Build help keys list
+	keys := []key.Binding{
+		m.keyMap.Submit,
+		m.keyMap.Cancel,
+		m.keyMap.Next,
+		m.keyMap.Prev,
+	}
+
+	helpParts := make([]string, len(keys))
+	for i, k := range keys {
+		helpParts[i] = fmt.Sprintf("%s %s", k.Help().Key, k.Help().Desc)
+	}
+
+	return lipgloss.NewStyle().Faint(true).Render(strings.Join(helpParts, " | "))
+}
+
+// SetProfileData populates the form with existing profile data for editing
+func (m *ProfileFormModel) SetProfileData(name, description string) {
+	m.nameInput.SetValue(name)
+	m.descriptionInput.SetValue(description)
+	m.isAddMode = false // Set to edit mode
+
+	// Note: In a real implementation, we would also set values for tool directories,
+	// tool files, prompt directories, and prompt files from the existing profile.
+	// This would require extracting this data from the profile structure.
+}
+
+// GetProfileData retrieves the profile data from the form
+func (m *ProfileFormModel) GetProfileData() (string, string, error) {
+	name := m.nameInput.Value()
+	if name == "" {
+		return "", "", fmt.Errorf("profile name is required")
+	}
+
+	description := m.descriptionInput.Value()
+
+	return name, description, nil
+}
+
+// ParsePathList parses a comma-separated list of paths into a slice of strings
+func (m *ProfileFormModel) ParsePathList(input string) []string {
+	if input == "" {
+		return []string{}
+	}
+
+	paths := strings.Split(input, ",")
+	result := make([]string, 0, len(paths))
+
+	for _, path := range paths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+
+	return result
+}
+
+// GetToolsAndPrompts retrieves tool and prompt configuration from the form
+func (m *ProfileFormModel) GetToolsAndPrompts() ([]string, []string, []string, []string) {
+	toolDirs := m.ParsePathList(m.toolDirsInput.Value())
+	toolFiles := m.ParsePathList(m.toolFilesInput.Value())
+	promptDirs := m.ParsePathList(m.promptDirsInput.Value())
+	promptFiles := m.ParsePathList(m.promptFilesInput.Value())
+	return toolDirs, toolFiles, promptDirs, promptFiles
+}


### PR DESCRIPTION
This PR adds profile management capabilities to the TUI, allowing users to
create, edit, and manage MCP profiles directly through the interface. It also
enhances shell commands with JSON argument handling.

## Profile management features
- Add new top-level "Profile Config" menu option
- Create dedicated profile form with fields for:
  - Profile name and description
  - Tool directories and files (comma-separated)
  - Prompt directories and files (comma-separated)

## Shell command enhancements
- Add JSON argument support for shell commands
  - All arguments automatically saved to temporary JSON file
  - Path provided via `MCP_ARGUMENTS_JSON_PATH` environment variable
  - Makes it easier to access complex arguments in scripts using tools like jq
- Add optional `save-script-dir` to preserve generated scripts and args
- Add `debug` flag to control script logging

## UI improvements
- Refactor form submission to use Alt+S instead of Enter
- Convert environment variable input to multi-line textarea