### PR TITLE
Include stderr output in error messages

### DIFF
--- a/examples/sqleton/sql-query.yaml
+++ b/examples/sqleton/sql-query.yaml
@@ -1,0 +1,40 @@
+name: sql-query
+short: Execute SQL query using sqleton
+long: |
+  Execute a SQL query against a database using sqleton.
+  The query is properly escaped to ensure safe execution.
+  Results are displayed in CSV format by default.
+
+flags:
+  - name: query
+    type: string
+    help: SQL query to execute
+    required: true
+  - name: format
+    type: choice
+    help: Output format
+    choices:
+      - table
+      - json
+      - csv
+    default: csv
+
+shell-script: |
+  #!/bin/bash
+  set -euo pipefail
+
+  # Get args from JSON file
+  ARGS_FILE="$MCP_ARGUMENTS_JSON_PATH"
+  echo "ARGS_FILE: $ARGS_FILE"
+  
+  # Extract and escape the query
+  QUERY=$(jq -r '.query' "$ARGS_FILE" | sed 's/"/\\"/g')
+  FORMAT=$(jq -r '.format' "$ARGS_FILE")
+
+  # Execute sqleton with proper escaping
+  sqleton query "$QUERY" --output "$FORMAT"
+
+# Save debug information
+save-script-dir: /tmp/sqleton-scripts
+debug: true
+capture-stderr: true

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/JohannesKaufmann/html-to-markdown v1.6.0 h1:04VXMiE50YYfCfLboJCLcgqF5x+rHJnb1ssNmqpLH/k=
 github.com/JohannesKaufmann/html-to-markdown v1.6.0/go.mod h1:NUI78lGg/a7vpEJTz/0uOcYMaibytE4BUOQS8k78yPQ=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/pkg/tools/providers/config-provider/tool-provider.go
+++ b/pkg/tools/providers/config-provider/tool-provider.go
@@ -3,6 +3,7 @@ package config_provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/go-go-golems/go-go-mcp/pkg/scholarly/mcp"
 	"os"
 	"path/filepath"
@@ -369,7 +370,7 @@ func (p *ConfigToolProvider) executeCommand(ctx context.Context, cmd cmds.Comman
 	switch c := cmd.(type) {
 	case cmds.WriterCommand:
 		if err := c.RunIntoWriter(ctx, parsedLayers, buf); err != nil {
-			return protocol.NewErrorToolResult(protocol.NewTextContent(err.Error())), nil
+			return protocol.NewErrorToolResult(protocol.NewTextContent(fmt.Sprintf("%s\n\nOutput so far:\n%s", err.Error(), buf.String()))), nil
 		}
 	case cmds.BareCommand:
 		panic("BareCommand not supported yet")


### PR DESCRIPTION
* Return stdout content along with error messages when commands fail
  * Previously only the error message was returned
  * Now both the error message and any captured stdout are included
  * Helps diagnose what happened before the failure